### PR TITLE
Remove HookContext

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,8 +74,8 @@ class Example extends HookWidget {
         super(key: key);
 
   @override
-  Widget build(HookContext context) {
-    final controller = context.useAnimationController(duration: duration);
+  Widget build(BuildContext context) {
+    final controller = useAnimationController(duration: duration);
     return Container();
   }
 }
@@ -95,9 +95,9 @@ Hooks are a new kind of objects with some specificities:
   The following code defines two independent `AnimationController`, and they are correctly preserved when the widget rebuild.
 
 ```dart
-Widget build(HookContext context) {
-  final controller = context.useAnimationController();
-  final controller2 = context.useAnimationController();
+Widget build(BuildContext context) {
+  final controller = useAnimationController();
+  final controller2 = useAnimationController();
   return Container();
 }
 ```
@@ -106,7 +106,7 @@ Widget build(HookContext context) {
 
 ## Principle
 
-Similarily to `State`, hooks are stored on the `Element` of a `Widget`. But instead of having one `State`, the `Element` stores a `List<Hook>`. Then to use a `Hook`, one must call `HookContext.use`.
+Similarily to `State`, hooks are stored on the `Element` of a `Widget`. But instead of having one `State`, the `Element` stores a `List<Hook>`. Then to use a `Hook`, one must call `Hook.use`.
 
 The hook returned by `use` is based on the number of times it has been called. The first call returns the first hook; the second call returns the second hook, the third returns the third hook, ...
 
@@ -136,8 +136,8 @@ Due to hooks being obtained from their index, there are some rules that must be 
 ### DO call `use` unconditionally
 
 ```dart
-Widget build(HookContext context) {
-  context.use(MyHook());
+Widget build(BuildContext context) {
+  Hook.use(MyHook());
   // ....
 }
 ```
@@ -145,9 +145,9 @@ Widget build(HookContext context) {
 ### DON'T wrap `use` into a condition
 
 ```dart
-Widget build(HookContext context) {
+Widget build(BuildContext context) {
   if (condition) {
-    context.use(MyHook());
+    Hook.use(MyHook());
   }
   // ....
 }
@@ -158,9 +158,9 @@ Widget build(HookContext context) {
 ### DO always call all the hooks:
 
 ```dart
-Widget build(HookContext context) {
-  context.use(Hook1());
-  context.use(Hook2());
+Widget build(BuildContext context) {
+  Hook.use(Hook1());
+  Hook.use(Hook2());
   // ....
 }
 ```
@@ -168,12 +168,12 @@ Widget build(HookContext context) {
 ### DON'T aborts `build` method before all hooks have been called:
 
 ```dart
-Widget build(HookContext context) {
-  context.use(Hook1());
+Widget build(BuildContext context) {
+  Hook.use(Hook1());
   if (condition) {
     return Container();
   }
-  context.use(Hook2());
+  Hook.use(Hook2());
   // ....
 }
 ```
@@ -189,17 +189,17 @@ But worry not, `HookWidget` overrides the default hot-reload behavior to work wi
 Consider the following list of hooks:
 
 ```dart
-context.use(HookA());
-context.use(HookB(0));
-context.use(HookC(0));
+Hook.use(HookA());
+Hook.use(HookB(0));
+Hook.use(HookC(0));
 ```
 
 Then consider that after a hot-reload, we edited the parameter of `HookB`:
 
 ```dart
-context.use(HookA());
-context.use(HookB(42));
-context.use(HookC());
+Hook.use(HookA());
+Hook.use(HookB(42));
+Hook.use(HookC());
 ```
 
 Here everything works fine; all hooks keep their states.
@@ -207,8 +207,8 @@ Here everything works fine; all hooks keep their states.
 Now consider that we removed `HookB`. We now have:
 
 ```dart
-context.use(HookA());
-context.use(HookC());
+Hook.use(HookA());
+Hook.use(HookC());
 ```
 
 In this situation, `HookA` keeps its state but `HookC` gets a hard reset.
@@ -225,9 +225,9 @@ Functions is by far the most common way to write a hook. Thanks to hooks being c
 The following defines a custom hook that creates a variable and logs its value on the console whenever the value changes:
 
 ```dart
-ValueNotifier<T> useLoggedState<T>(HookContext context, [T initialData]) {
-  final result = context.useState<T>(initialData);
-  context.useValueChanged(result.value, (_, __) {
+ValueNotifier<T> useLoggedState<T>(BuildContext context, [T initialData]) {
+  final result = useState<T>(initialData);
+  useValueChanged(result.value, (_, __) {
     print(result.value);
   });
   return result;
@@ -236,11 +236,11 @@ ValueNotifier<T> useLoggedState<T>(HookContext context, [T initialData]) {
 
 - A class
 
-When a hook becomes too complex, it is possible to convert it into a class that extends `Hook`, which can then be used using `HookContext.use`. As a class, the hook will look very similar to a `State` and have access to life-cycles and methods such as `initHook`, `dispose` and `setState`. It is usually a good practice to hide the class under a function as such:
+When a hook becomes too complex, it is possible to convert it into a class that extends `Hook`, which can then be used using `Hook.use`. As a class, the hook will look very similar to a `State` and have access to life-cycles and methods such as `initHook`, `dispose` and `setState`. It is usually a good practice to hide the class under a function as such:
 
 ```dart
-Result useMyHook(HookContext context) {
-  return context.use(_MyHook());
+Result useMyHook(BuildContext context) {
+  return Hook.use(_MyHook());
 }
 ```
 
@@ -264,7 +264,7 @@ class _TimeAliveState<T> extends HookState<void, _TimeAlive<T>> {
   }
 
   @override
-  void build(HookContext context) {
+  void build(BuildContext context) {
     // this hook doesn't create anything nor uses other hooks
   }
 
@@ -279,7 +279,7 @@ class _TimeAliveState<T> extends HookState<void, _TimeAlive<T>> {
 
 ## Existing hooks
 
-`HookContext` comes with a list of predefined hooks that are commonly used. They can be used directly on the `HookContext` instance. The existing hooks are:
+Flutter_hooks comes with a list of reusable hooks already provided. They are static methods free to use that includes:
 
 - useEffect
 
@@ -291,7 +291,7 @@ The following call to `useEffect` subscribes to a `Stream` and cancel the subscr
 
 ```dart
 Stream stream;
-context.useEffect(() {
+useEffect(() {
     final subscribtion = stream.listen(print);
     // This will cancel the subscribtion when the widget is disposed
     // or if the callback is called again.
@@ -311,8 +311,8 @@ The following code uses `useState` to make a counter application:
 ```dart
 class Counter extends HookWidget {
   @override
-  Widget build(HookContext context) {
-    final counter = context.useState(0);
+  Widget build(BuildContext context) {
+    final counter = useState(0);
 
     return GestureDetector(
       // automatically triggers a rebuild of Counter widget
@@ -333,7 +333,7 @@ The following sample make an http call and return the created `Future`. And if `
 
 ```dart
 String userId;
-final Future<http.Response> response = context.useMemoized(() {
+final Future<http.Response> response = useMemoized(() {
   return http.get('someUrl/$userId');
 }, [userId]);
 ```
@@ -348,7 +348,7 @@ The following example implicitly starts a tween animation whenever `color` chang
 AnimationController controller;
 Color color;
 
-final colorTween = context.useValueChanged(
+final colorTween = useValueChanged(
     color,
     (Color oldColor, Animation<Color> oldAnimation) {
       return ColorTween(
@@ -368,7 +368,7 @@ They are the equivalent of both `initState`, `dispose` and `didUpdateWidget` for
 
 ```dart
 Duration duration;
-AnimationController controller = context.useAnimationController(
+AnimationController controller = useAnimationController(
   // duration is automatically updates when the widget is rebuilt with a different `duration`
   duration: duration,
 );
@@ -381,5 +381,5 @@ A set of hooks that subscribes to an object and calls `setState` accordingly.
 ```dart
 Stream<int> stream;
 // automatically rebuild the widget when a new value is pushed to the stream
-AsyncSnapshot<int> snapshot = context.useStream(stream);
+AsyncSnapshot<int> snapshot = useStream(stream);
 ```

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -21,7 +21,7 @@ class _Counter extends HookWidget {
   const _Counter({Key key}) : super(key: key);
 
   @override
-  Widget build(HookContext context) {
+  Widget build(BuildContext context) {
     StreamController<int> countController =
         _useLocalStorageInt(context, 'counter');
     return Scaffold(
@@ -31,8 +31,7 @@ class _Counter extends HookWidget {
       body: Center(
         child: HookBuilder(
           builder: (context) {
-            AsyncSnapshot<int> count =
-                context.useStream(countController.stream);
+            AsyncSnapshot<int> count = useStream(countController.stream);
 
             return !count.hasData
                 // Currently loading value from local storage, or there's an error
@@ -49,33 +48,32 @@ class _Counter extends HookWidget {
 }
 
 StreamController<int> _useLocalStorageInt(
-  HookContext context,
+  BuildContext context,
   String key, {
   int defaultValue = 0,
 }) {
-  final controller = context.useStreamController<int>(keys: <dynamic>[key]);
+  final controller = useStreamController<int>(keys: <dynamic>[key]);
 
-  context
-    // We define a callback that will be called on first build
-    // and whenever the controller/key change
-    ..useEffect(() {
-      // We listen to the data and push new values to local storage
-      final sub = controller.stream.listen((data) async {
-        final prefs = await SharedPreferences.getInstance();
-        await prefs.setInt(key, data);
-      });
-      // Unsubscribe when the widget is disposed
-      // or on controller/key change
-      return sub.cancel;
-    }, <dynamic>[controller, key])
-    // We load the initial value
-    ..useEffect(() {
-      SharedPreferences.getInstance().then((prefs) async {
-        int valueFromStorage = prefs.getInt(key);
-        controller.add(valueFromStorage ?? defaultValue);
-      }).catchError(controller.addError);
-      // ensure the callback is called only on first build
-    }, <dynamic>[controller, key]);
+  // We define a callback that will be called on first build
+  // and whenever the controller/key change
+  useEffect(() {
+    // We listen to the data and push new values to local storage
+    final sub = controller.stream.listen((data) async {
+      final prefs = await SharedPreferences.getInstance();
+      await prefs.setInt(key, data);
+    });
+    // Unsubscribe when the widget is disposed
+    // or on controller/key change
+    return sub.cancel;
+  }, <dynamic>[controller, key]);
+  // We load the initial value
+  useEffect(() {
+    SharedPreferences.getInstance().then((prefs) async {
+      int valueFromStorage = prefs.getInt(key);
+      controller.add(valueFromStorage ?? defaultValue);
+    }).catchError(controller.addError);
+    // ensure the callback is called only on first build
+  }, <dynamic>[controller, key]);
 
   return controller;
 }

--- a/lib/src/hook_impl.dart
+++ b/lib/src/hook_impl.dart
@@ -22,7 +22,7 @@ class _MemoizedHookState<T> extends HookState<T, _MemoizedHook<T>> {
   }
 
   @override
-  T build(HookContext context) {
+  T build(BuildContext context) {
     return value;
   }
 }
@@ -51,7 +51,7 @@ class _ValueChangedHookState<T, R>
   }
 
   @override
-  R build(HookContext context) {
+  R build(BuildContext context) {
     return _result;
   }
 }
@@ -81,7 +81,7 @@ class _StateHookState<T> extends HookState<ValueNotifier<T>, _StateHook<T>> {
   }
 
   @override
-  ValueNotifier<T> build(HookContext context) {
+  ValueNotifier<T> build(BuildContext context) {
     return _state;
   }
 
@@ -131,7 +131,7 @@ class _TickerProviderHookState
   }
 
   @override
-  TickerProvider build(HookContext context) {
+  TickerProvider build(BuildContext context) {
     if (_ticker != null) _ticker.muted = !TickerMode.of(context);
     return this;
   }
@@ -182,9 +182,8 @@ Switching between controller and uncontrolled vsync is not allowed.
   }
 
   @override
-  AnimationController build(HookContext context) {
-    final vsync =
-        hook.vsync ?? context.useSingleTickerProvider(keys: hook.keys);
+  AnimationController build(BuildContext context) {
+    final vsync = hook.vsync ?? useSingleTickerProvider(keys: hook.keys);
 
     _animationController ??= AnimationController(
       vsync: vsync,
@@ -232,7 +231,7 @@ class _ListenableStateHook extends HookState<void, _ListenableHook> {
   }
 
   @override
-  void build(HookContext context) {}
+  void build(BuildContext context) {}
 
   void _listener() {
     setState(() {});
@@ -314,7 +313,7 @@ class _FutureStateHook<T> extends HookState<AsyncSnapshot<T>, _FutureHook<T>> {
   }
 
   @override
-  AsyncSnapshot<T> build(HookContext context) {
+  AsyncSnapshot<T> build(BuildContext context) {
     return _snapshot;
   }
 }
@@ -386,7 +385,7 @@ class _StreamHookState<T> extends HookState<AsyncSnapshot<T>, _StreamHook<T>> {
   }
 
   @override
-  AsyncSnapshot<T> build(HookContext context) {
+  AsyncSnapshot<T> build(BuildContext context) {
     return _summary;
   }
 
@@ -444,7 +443,7 @@ class _EffectHookState extends HookState<void, _EffectHook> {
   }
 
   @override
-  void build(HookContext context) {}
+  void build(BuildContext context) {}
 
   @override
   void dispose() {
@@ -499,7 +498,7 @@ class _StreamControllerHookState<T>
   }
 
   @override
-  StreamController<T> build(HookContext context) {
+  StreamController<T> build(BuildContext context) {
     return _controller;
   }
 

--- a/test/hook_builder_test.dart
+++ b/test/hook_builder_test.dart
@@ -6,7 +6,7 @@ import 'mock.dart';
 
 void main() {
   testWidgets('simple build', (tester) async {
-    final fn = Func1<HookContext, Widget>();
+    final fn = Func1<BuildContext, Widget>();
     when(fn.call(any)).thenAnswer((_) {
       return Container();
     });

--- a/test/hook_widget_test.dart
+++ b/test/hook_widget_test.dart
@@ -6,11 +6,11 @@ import 'package:flutter_hooks/flutter_hooks.dart';
 import 'mock.dart';
 
 void main() {
-  final build = Func1<HookContext, int>();
+  final build = Func1<BuildContext, int>();
   final dispose = Func0<void>();
   final initHook = Func0<void>();
   final didUpdateHook = Func1<HookTest, void>();
-  final builder = Func1<HookContext, Widget>();
+  final builder = Func1<BuildContext, Widget>();
 
   final createHook = () => HookTest<int>(
         build: build.call,
@@ -33,9 +33,8 @@ void main() {
 
     final dispose2 = Func0<void>();
     when(builder.call(any)).thenAnswer((invocation) {
-      (invocation.positionalArguments[0] as HookContext)
-        ..use(HookTest<int>(dispose: dispose.call, keys: keys))
-        ..use(HookTest<String>(dispose: dispose2.call, keys: keys2));
+      Hook.use(HookTest<int>(dispose: dispose.call, keys: keys));
+      Hook.use(HookTest<String>(dispose: dispose2.call, keys: keys2));
       return Container();
     });
     await tester.pumpWidget(HookBuilder(builder: builder.call));
@@ -62,15 +61,14 @@ void main() {
     when(createState.call()).thenReturn(HookStateTest<int>());
 
     when(builder.call(any)).thenAnswer((invocation) {
-      (invocation.positionalArguments[0] as HookContext)
-        ..use(HookTest<int>(
-          build: build.call,
-          dispose: dispose.call,
-          didUpdateHook: didUpdateHook.call,
-          initHook: initHook.call,
-          keys: keys,
-          createStateFn: createState.call,
-        ));
+      Hook.use(HookTest<int>(
+        build: build.call,
+        dispose: dispose.call,
+        didUpdateHook: didUpdateHook.call,
+        initHook: initHook.call,
+        keys: keys,
+        createStateFn: createState.call,
+      ));
       return Container();
     });
     await tester.pumpWidget(HookBuilder(builder: builder.call));
@@ -173,7 +171,7 @@ void main() {
     await tester.pumpWidget(HookBuilder(
       builder: (context) {
         hookContext = context as HookElement;
-        state = context.use(hook);
+        state = Hook.use(hook);
         return Container();
       },
     ));
@@ -194,9 +192,8 @@ void main() {
 
     when(build.call(any)).thenReturn(42);
     when(builder.call(any)).thenAnswer((invocation) {
-      HookContext context = invocation.positionalArguments[0];
       previousHook = createHook();
-      result = context.use(previousHook);
+      result = Hook.use(previousHook);
       return Container();
     });
 
@@ -247,9 +244,8 @@ void main() {
 
     when(build.call(any)).thenReturn(42);
     when(builder.call(any)).thenAnswer((invocation) {
-      invocation.positionalArguments[0]
-        ..use(createHook())
-        ..use(HookTest<int>(dispose: dispose2));
+      Hook.use(createHook());
+      Hook.use(HookTest<int>(dispose: dispose2));
       return Container();
     });
 
@@ -271,7 +267,7 @@ void main() {
     final hook = createHook();
 
     when(builder.call(any)).thenAnswer((invocation) {
-      invocation.positionalArguments[0].use(hook);
+      Hook.use(hook);
       return Container();
     });
 
@@ -296,14 +292,14 @@ void main() {
 
   testWidgets('rebuild with different hooks crash', (tester) async {
     when(builder.call(any)).thenAnswer((invocation) {
-      invocation.positionalArguments[0].use(HookTest<int>());
+      Hook.use(HookTest<int>());
       return Container();
     });
 
     await tester.pumpWidget(HookBuilder(builder: builder.call));
 
     when(builder.call(any)).thenAnswer((invocation) {
-      invocation.positionalArguments[0].use(HookTest<String>());
+      Hook.use(HookTest<String>());
       return Container();
     });
 
@@ -314,15 +310,15 @@ void main() {
   });
   testWidgets('rebuild added hooks crash', (tester) async {
     when(builder.call(any)).thenAnswer((invocation) {
-      invocation.positionalArguments[0].use(HookTest<int>());
+      Hook.use(HookTest<int>());
       return Container();
     });
 
     await tester.pumpWidget(HookBuilder(builder: builder.call));
 
     when(builder.call(any)).thenAnswer((invocation) {
-      invocation.positionalArguments[0].use(HookTest<int>());
-      invocation.positionalArguments[0].use(HookTest<String>());
+      Hook.use(HookTest<int>());
+      Hook.use(HookTest<String>());
       return Container();
     });
 
@@ -332,7 +328,7 @@ void main() {
 
   testWidgets('rebuild removed hooks crash', (tester) async {
     when(builder.call(any)).thenAnswer((invocation) {
-      invocation.positionalArguments[0].use(HookTest<int>());
+      Hook.use(HookTest<int>());
       return Container();
     });
 
@@ -356,7 +352,7 @@ void main() {
     final context =
         tester.firstElement(find.byType(HookBuilder)) as HookElement;
 
-    expect(() => context.use(HookTest<int>()), throwsAssertionError);
+    expect(() => Hook.use(HookTest<int>()), throwsAssertionError);
   });
 
   testWidgets('hot-reload triggers a build', (tester) async {
@@ -365,9 +361,8 @@ void main() {
 
     when(build.call(any)).thenReturn(42);
     when(builder.call(any)).thenAnswer((invocation) {
-      HookContext context = invocation.positionalArguments[0];
       previousHook = createHook();
-      result = context.use(previousHook);
+      result = Hook.use(previousHook);
       return Container();
     });
 
@@ -402,11 +397,10 @@ void main() {
     final dispose2 = Func0<void>();
     final initHook2 = Func0<void>();
     final didUpdateHook2 = Func1<HookTest, void>();
-    final build2 = Func1<HookContext, String>();
+    final build2 = Func1<BuildContext, String>();
 
     when(builder.call(any)).thenAnswer((invocation) {
-      (invocation.positionalArguments[0] as HookContext)
-        ..use(hook1 = createHook());
+      Hook.use(hook1 = createHook());
       return Container();
     });
 
@@ -422,14 +416,13 @@ void main() {
     verifyZeroInteractions(didUpdateHook);
 
     when(builder.call(any)).thenAnswer((invocation) {
-      (invocation.positionalArguments[0] as HookContext)
-        ..use(createHook())
-        ..use(HookTest<String>(
-          initHook: initHook2,
-          build: build2,
-          didUpdateHook: didUpdateHook2,
-          dispose: dispose2,
-        ));
+      Hook.use(createHook());
+      Hook.use(HookTest<String>(
+        initHook: initHook2,
+        build: build2,
+        didUpdateHook: didUpdateHook2,
+        dispose: dispose2,
+      ));
       return Container();
     });
 
@@ -453,10 +446,10 @@ void main() {
     final dispose2 = Func0<void>();
     final initHook2 = Func0<void>();
     final didUpdateHook2 = Func1<HookTest, void>();
-    final build2 = Func1<HookContext, String>();
+    final build2 = Func1<BuildContext, String>();
 
     when(builder.call(any)).thenAnswer((invocation) {
-      (invocation.positionalArguments[0] as HookContext)..use(createHook());
+      Hook.use(createHook());
       return Container();
     });
 
@@ -472,14 +465,13 @@ void main() {
     verifyZeroInteractions(didUpdateHook);
 
     when(builder.call(any)).thenAnswer((invocation) {
-      (invocation.positionalArguments[0] as HookContext)
-        ..use(HookTest<String>(
-          initHook: initHook2,
-          build: build2,
-          didUpdateHook: didUpdateHook2,
-          dispose: dispose2,
-        ))
-        ..use(createHook());
+      Hook.use(HookTest<String>(
+        initHook: initHook2,
+        build: build2,
+        didUpdateHook: didUpdateHook2,
+        dispose: dispose2,
+      ));
+      Hook.use(createHook());
       return Container();
     });
 
@@ -502,17 +494,16 @@ void main() {
     final dispose2 = Func0<void>();
     final initHook2 = Func0<void>();
     final didUpdateHook2 = Func1<HookTest, void>();
-    final build2 = Func1<HookContext, int>();
+    final build2 = Func1<BuildContext, int>();
 
     when(builder.call(any)).thenAnswer((invocation) {
-      (invocation.positionalArguments[0] as HookContext)
-        ..use(createHook())
-        ..use(HookTest<int>(
-          initHook: initHook2,
-          build: build2,
-          didUpdateHook: didUpdateHook2,
-          dispose: dispose2,
-        ));
+      Hook.use(createHook());
+      Hook.use(HookTest<int>(
+        initHook: initHook2,
+        build: build2,
+        didUpdateHook: didUpdateHook2,
+        dispose: dispose2,
+      ));
       return Container();
     });
 
@@ -557,24 +548,23 @@ void main() {
     final dispose2 = Func0<void>();
     final initHook2 = Func0<void>();
     final didUpdateHook2 = Func1<HookTest, void>();
-    final build2 = Func1<HookContext, int>();
+    final build2 = Func1<BuildContext, int>();
 
     final dispose3 = Func0<void>();
     final initHook3 = Func0<void>();
     final didUpdateHook3 = Func1<HookTest, void>();
-    final build3 = Func1<HookContext, int>();
+    final build3 = Func1<BuildContext, int>();
 
     final dispose4 = Func0<void>();
     final initHook4 = Func0<void>();
     final didUpdateHook4 = Func1<HookTest, void>();
-    final build4 = Func1<HookContext, int>();
+    final build4 = Func1<BuildContext, int>();
 
     when(builder.call(any)).thenAnswer((invocation) {
-      (invocation.positionalArguments[0] as HookContext)
-        ..use(hook1 = createHook())
-        ..use(HookTest<String>(dispose: dispose2))
-        ..use(HookTest<Object>(dispose: dispose3))
-        ..use(HookTest<void>(dispose: dispose4));
+      Hook.use(hook1 = createHook());
+      Hook.use(HookTest<String>(dispose: dispose2));
+      Hook.use(HookTest<Object>(dispose: dispose3));
+      Hook.use(HookTest<void>(dispose: dispose4));
       return Container();
     });
 
@@ -604,24 +594,23 @@ void main() {
     clearInteractions(build4);
 
     when(builder.call(any)).thenAnswer((invocation) {
-      (invocation.positionalArguments[0] as HookContext)
-        ..use(createHook())
-        // changed type from HookTest<String>
-        ..use(HookTest<int>(
-          initHook: initHook2,
-          build: build2,
-          didUpdateHook: didUpdateHook2,
-        ))
-        ..use(HookTest<int>(
-          initHook: initHook3,
-          build: build3,
-          didUpdateHook: didUpdateHook3,
-        ))
-        ..use(HookTest<int>(
-          initHook: initHook4,
-          build: build4,
-          didUpdateHook: didUpdateHook4,
-        ));
+      Hook.use(createHook());
+      // changed type from HookTest<String>
+      Hook.use(HookTest<int>(
+        initHook: initHook2,
+        build: build2,
+        didUpdateHook: didUpdateHook2,
+      ));
+      Hook.use(HookTest<int>(
+        initHook: initHook3,
+        build: build3,
+        didUpdateHook: didUpdateHook3,
+      ));
+      Hook.use(HookTest<int>(
+        initHook: initHook4,
+        build: build4,
+        didUpdateHook: didUpdateHook4,
+      ));
       return Container();
     });
 
@@ -654,24 +643,23 @@ void main() {
     final dispose2 = Func0<void>();
     final initHook2 = Func0<void>();
     final didUpdateHook2 = Func1<HookTest, void>();
-    final build2 = Func1<HookContext, int>();
+    final build2 = Func1<BuildContext, int>();
 
     final dispose3 = Func0<void>();
     final initHook3 = Func0<void>();
     final didUpdateHook3 = Func1<HookTest, void>();
-    final build3 = Func1<HookContext, int>();
+    final build3 = Func1<BuildContext, int>();
 
     final dispose4 = Func0<void>();
     final initHook4 = Func0<void>();
     final didUpdateHook4 = Func1<HookTest, void>();
-    final build4 = Func1<HookContext, int>();
+    final build4 = Func1<BuildContext, int>();
 
     when(builder.call(any)).thenAnswer((invocation) {
-      (invocation.positionalArguments[0] as HookContext)
-        ..use(hook1 = createHook())
-        ..use(HookTest<String>(dispose: dispose2))
-        ..use(HookTest<Object>(dispose: dispose3))
-        ..use(HookTest<void>(dispose: dispose4));
+      Hook.use(hook1 = createHook());
+      Hook.use(HookTest<String>(dispose: dispose2));
+      Hook.use(HookTest<Object>(dispose: dispose3));
+      Hook.use(HookTest<void>(dispose: dispose4));
       return Container();
     });
 
@@ -701,24 +689,23 @@ void main() {
     clearInteractions(build4);
 
     when(builder.call(any)).thenAnswer((invocation) {
-      (invocation.positionalArguments[0] as HookContext)
-        ..use(createHook())
-        // changed type from HookTest<String>
-        ..use(HookTest<int>(
-          initHook: initHook2,
-          build: build2,
-          didUpdateHook: didUpdateHook2,
-        ))
-        ..use(HookTest<int>(
-          initHook: initHook3,
-          build: build3,
-          didUpdateHook: didUpdateHook3,
-        ))
-        ..use(HookTest<int>(
-          initHook: initHook4,
-          build: build4,
-          didUpdateHook: didUpdateHook4,
-        ));
+      Hook.use(createHook());
+      // changed type from HookTest<String>
+      Hook.use(HookTest<int>(
+        initHook: initHook2,
+        build: build2,
+        didUpdateHook: didUpdateHook2,
+      ));
+      Hook.use(HookTest<int>(
+        initHook: initHook3,
+        build: build3,
+        didUpdateHook: didUpdateHook3,
+      ));
+      Hook.use(HookTest<int>(
+        initHook: initHook4,
+        build: build4,
+        didUpdateHook: didUpdateHook4,
+      ));
       return Container();
     });
 
@@ -764,7 +751,7 @@ class MyHook extends Hook<MyHookState> {
 
 class MyHookState extends HookState<MyHookState, MyHook> {
   @override
-  MyHookState build(HookContext context) {
+  MyHookState build(BuildContext context) {
     return this;
   }
 }

--- a/test/memoized_test.dart
+++ b/test/memoized_test.dart
@@ -4,7 +4,7 @@ import 'package:flutter_hooks/flutter_hooks.dart';
 import 'mock.dart';
 
 void main() {
-  final builder = Func1<HookContext, Widget>();
+  final builder = Func1<BuildContext, Widget>();
   final parameterBuilder = Func0<List>();
   final valueBuilder = Func0<int>();
 
@@ -16,13 +16,13 @@ void main() {
 
   testWidgets('invalid parameters', (tester) async {
     await tester.pumpWidget(HookBuilder(builder: (context) {
-      context.useMemoized<dynamic>(null);
+      useMemoized<dynamic>(null);
       return Container();
     }));
     expect(tester.takeException(), isAssertionError);
 
     await tester.pumpWidget(HookBuilder(builder: (context) {
-      context.useMemoized<dynamic>(() {}, null);
+      useMemoized<dynamic>(() {}, null);
       return Container();
     }));
     expect(tester.takeException(), isAssertionError);
@@ -35,8 +35,7 @@ void main() {
     when(valueBuilder.call()).thenReturn(42);
 
     when(builder.call(any)).thenAnswer((invocation) {
-      final HookContext context = invocation.positionalArguments.single;
-      result = context.useMemoized<int>(valueBuilder.call);
+      result = useMemoized<int>(valueBuilder.call);
       return Container();
     });
 
@@ -65,9 +64,7 @@ void main() {
     when(parameterBuilder.call()).thenReturn(<dynamic>[]);
 
     when(builder.call(any)).thenAnswer((invocation) {
-      final HookContext context = invocation.positionalArguments.single;
-      result =
-          context.useMemoized<int>(valueBuilder.call, parameterBuilder.call());
+      result = useMemoized<int>(valueBuilder.call, parameterBuilder.call());
       return Container();
     });
 
@@ -131,9 +128,7 @@ void main() {
     int result;
 
     when(builder.call(any)).thenAnswer((invocation) {
-      final HookContext context = invocation.positionalArguments.single;
-      result =
-          context.useMemoized<int>(valueBuilder.call, parameterBuilder.call());
+      result = useMemoized<int>(valueBuilder.call, parameterBuilder.call());
       return Container();
     });
 
@@ -209,9 +204,7 @@ void main() {
     final parameters = <dynamic>[];
 
     when(builder.call(any)).thenAnswer((invocation) {
-      final HookContext context = invocation.positionalArguments.single;
-      result =
-          context.useMemoized<int>(valueBuilder.call, parameterBuilder.call());
+      result = useMemoized<int>(valueBuilder.call, parameterBuilder.call());
       return Container();
     });
 

--- a/test/mock.dart
+++ b/test/mock.dart
@@ -26,7 +26,7 @@ abstract class _Func2<T1, T2, R> {
 class Func2<T1, T2, R> extends Mock implements _Func2<T1, T2, R> {}
 
 class HookTest<R> extends Hook<R> {
-  final R Function(HookContext context) build;
+  final R Function(BuildContext context) build;
   final void Function() dispose;
   final void Function() initHook;
   final void Function(HookTest<R> previousHook) didUpdateHook;
@@ -72,7 +72,7 @@ class HookStateTest<R> extends HookState<R, HookTest<R>> {
   }
 
   @override
-  R build(HookContext context) {
+  R build(BuildContext context) {
     if (hook.build != null) {
       return hook.build(context);
     }

--- a/test/use_animation_controller_test.dart
+++ b/test/use_animation_controller_test.dart
@@ -10,7 +10,7 @@ void main() {
 
     await tester.pumpWidget(
       HookBuilder(builder: (context) {
-        controller = context.useAnimationController();
+        controller = useAnimationController();
         return Container();
       }),
     );
@@ -43,7 +43,7 @@ void main() {
 
     await tester.pumpWidget(
       HookBuilder(builder: (context) {
-        controller = context.useAnimationController(
+        controller = useAnimationController(
           vsync: provider,
           animationBehavior: AnimationBehavior.preserve,
           duration: const Duration(seconds: 1),
@@ -77,7 +77,7 @@ void main() {
 
     await tester.pumpWidget(
       HookBuilder(builder: (context) {
-        controller = context.useAnimationController(
+        controller = useAnimationController(
           vsync: provider,
           animationBehavior: AnimationBehavior.normal,
           duration: const Duration(seconds: 2),
@@ -108,7 +108,7 @@ void main() {
       (tester) async {
     await tester.pumpWidget(HookBuilder(
       builder: (context) {
-        context.useAnimationController();
+        useAnimationController();
         return Container();
       },
     ));
@@ -116,7 +116,7 @@ void main() {
     await expectPump(
       () => tester.pumpWidget(HookBuilder(
             builder: (context) {
-              context.useAnimationController(vsync: tester);
+              useAnimationController(vsync: tester);
               return Container();
             },
           )),
@@ -128,7 +128,7 @@ void main() {
     // the other way around
     await tester.pumpWidget(HookBuilder(
       builder: (context) {
-        context.useAnimationController(vsync: tester);
+        useAnimationController(vsync: tester);
         return Container();
       },
     ));
@@ -136,7 +136,7 @@ void main() {
     await expectPump(
       () => tester.pumpWidget(HookBuilder(
             builder: (context) {
-              context.useAnimationController();
+              useAnimationController();
               return Container();
             },
           )),
@@ -149,7 +149,7 @@ void main() {
     AnimationController controller;
     await tester.pumpWidget(HookBuilder(
       builder: (context) {
-        controller = context.useAnimationController(keys: keys);
+        controller = useAnimationController(keys: keys);
         return Container();
       },
     ));
@@ -159,7 +159,7 @@ void main() {
 
     await tester.pumpWidget(HookBuilder(
       builder: (context) {
-        controller = context.useAnimationController(keys: keys);
+        controller = useAnimationController(keys: keys);
         return Container();
       },
     ));

--- a/test/use_animation_test.dart
+++ b/test/use_animation_test.dart
@@ -8,7 +8,7 @@ void main() {
     await expectPump(
         () => tester.pumpWidget(HookBuilder(
               builder: (context) {
-                context.useAnimation<void>(null);
+                useAnimation<void>(null);
                 return Container();
               },
             )),
@@ -21,7 +21,7 @@ void main() {
 
     pump() => tester.pumpWidget(HookBuilder(
           builder: (context) {
-            result = context.useAnimation(listenable);
+            result = useAnimation(listenable);
             return Container();
           },
         ));

--- a/test/use_effect_test.dart
+++ b/test/use_effect_test.dart
@@ -8,7 +8,7 @@ final unrelated = Func0<void>();
 List parameters;
 
 Widget builder() => HookBuilder(builder: (context) {
-      context.useEffect(effect.call, parameters);
+      useEffect(effect.call, parameters);
       unrelated.call();
       return Container();
     });
@@ -22,7 +22,7 @@ void main() {
   testWidgets('useEffect null callback throws', (tester) async {
     await expectPump(
       () => tester.pumpWidget(HookBuilder(builder: (c) {
-            c.useEffect(null);
+            useEffect(null);
             return Container();
           })),
       throwsAssertionError,
@@ -36,7 +36,7 @@ void main() {
     when(effect.call()).thenReturn(dispose.call);
 
     builder() => HookBuilder(builder: (context) {
-          context.useEffect(effect.call);
+          useEffect(effect.call);
           unrelated.call();
           return Container();
         });
@@ -181,7 +181,7 @@ void main() {
     List parameters;
 
     builder() => HookBuilder(builder: (context) {
-          context.useEffect(effect.call, parameters);
+          useEffect(effect.call, parameters);
           return Container();
         });
 

--- a/test/use_future_test.dart
+++ b/test/use_future_test.dart
@@ -6,10 +6,10 @@ import 'package:flutter_hooks/flutter_hooks.dart';
 import 'mock.dart';
 
 void main() {
-  Widget Function(HookContext) snapshotText(Future<String> stream,
+  Widget Function(BuildContext) snapshotText(Future<String> stream,
       {String initialData}) {
     return (context) {
-      final snapshot = context.useFuture(stream, initialData: initialData);
+      final snapshot = useFuture(stream, initialData: initialData);
       return Text(snapshot.toString(), textDirection: TextDirection.ltr);
     };
   }

--- a/test/use_listenable_test.dart
+++ b/test/use_listenable_test.dart
@@ -8,7 +8,7 @@ void main() {
     await expectPump(
         () => tester.pumpWidget(HookBuilder(
               builder: (context) {
-                context.useListenable(null);
+                useListenable(null);
                 return Container();
               },
             )),
@@ -19,7 +19,7 @@ void main() {
 
     pump() => tester.pumpWidget(HookBuilder(
           builder: (context) {
-            context.useListenable(listenable);
+            useListenable(listenable);
             return Container();
           },
         ));

--- a/test/use_state_test.dart
+++ b/test/use_state_test.dart
@@ -11,7 +11,7 @@ void main() {
     await tester.pumpWidget(HookBuilder(
       builder: (context) {
         element = context as HookElement;
-        state = context.useState(42);
+        state = useState(42);
         return Container();
       },
     ));
@@ -45,7 +45,7 @@ void main() {
     await tester.pumpWidget(HookBuilder(
       builder: (context) {
         element = context as HookElement;
-        state = context.useState();
+        state = useState();
         return Container();
       },
     ));

--- a/test/use_stream_controller_test.dart
+++ b/test/use_stream_controller_test.dart
@@ -11,13 +11,13 @@ void main() {
       StreamController<int> controller;
 
       await tester.pumpWidget(HookBuilder(builder: (context) {
-        controller = context.useStreamController();
+        controller = useStreamController();
         return Container();
       }));
 
       final previous = controller;
       await tester.pumpWidget(HookBuilder(builder: (context) {
-        controller = context.useStreamController(keys: <dynamic>[]);
+        controller = useStreamController(keys: <dynamic>[]);
         return Container();
       }));
 
@@ -27,7 +27,7 @@ void main() {
       StreamController<int> controller;
 
       await tester.pumpWidget(HookBuilder(builder: (context) {
-        controller = context.useStreamController();
+        controller = useStreamController();
         return Container();
       }));
 
@@ -41,7 +41,7 @@ void main() {
       final onListen = () {};
       final onCancel = () {};
       await tester.pumpWidget(HookBuilder(builder: (context) {
-        controller = context.useStreamController(
+        controller = useStreamController(
           sync: true,
           onCancel: onCancel,
           onListen: onListen,
@@ -64,7 +64,7 @@ void main() {
       StreamController<int> controller;
 
       await tester.pumpWidget(HookBuilder(builder: (context) {
-        controller = context.useStreamController(sync: true);
+        controller = useStreamController(sync: true);
         return Container();
       }));
 
@@ -78,7 +78,7 @@ void main() {
       final onListen = () {};
       final onCancel = () {};
       await tester.pumpWidget(HookBuilder(builder: (context) {
-        controller = context.useStreamController(
+        controller = useStreamController(
           onCancel: onCancel,
           onListen: onListen,
         );

--- a/test/use_stream_test.dart
+++ b/test/use_stream_test.dart
@@ -8,10 +8,10 @@ import 'mock.dart';
 /// port of [StreamBuilder]
 ///
 void main() {
-  Widget Function(HookContext) snapshotText(Stream<String> stream,
+  Widget Function(BuildContext) snapshotText(Stream<String> stream,
       {String initialData}) {
     return (context) {
-      final snapshot = context.useStream(stream, initialData: initialData);
+      final snapshot = useStream(stream, initialData: initialData);
       return Text(snapshot.toString(), textDirection: TextDirection.ltr);
     };
   }

--- a/test/use_ticker_provider_test.dart
+++ b/test/use_ticker_provider_test.dart
@@ -11,7 +11,7 @@ void main() {
     await tester.pumpWidget(TickerMode(
       enabled: true,
       child: HookBuilder(builder: (context) {
-        provider = context.useSingleTickerProvider();
+        provider = useSingleTickerProvider();
         return Container();
       }),
     ));
@@ -29,7 +29,7 @@ void main() {
 
   testWidgets('useSingleTickerProvider unused', (tester) async {
     await tester.pumpWidget(HookBuilder(builder: (context) {
-      context.useSingleTickerProvider();
+      useSingleTickerProvider();
       return Container();
     }));
 
@@ -42,7 +42,7 @@ void main() {
     await tester.pumpWidget(TickerMode(
       enabled: true,
       child: HookBuilder(builder: (context) {
-        provider = context.useSingleTickerProvider();
+        provider = useSingleTickerProvider();
         return Container();
       }),
     ));
@@ -66,7 +66,7 @@ void main() {
     List keys;
 
     await tester.pumpWidget(HookBuilder(builder: (context) {
-      provider = context.useSingleTickerProvider(keys: keys);
+      provider = useSingleTickerProvider(keys: keys);
       return Container();
     }));
 
@@ -74,7 +74,7 @@ void main() {
     keys = <dynamic>[];
 
     await tester.pumpWidget(HookBuilder(builder: (context) {
-      provider = context.useSingleTickerProvider(keys: keys);
+      provider = useSingleTickerProvider(keys: keys);
       return Container();
     }));
 

--- a/test/use_value_changed_test.dart
+++ b/test/use_value_changed_test.dart
@@ -6,12 +6,12 @@ import 'mock.dart';
 void main() {
   testWidgets('useValueChanged basic', (tester) async {
     var value = 42;
-    final useValueChanged = Func2<int, String, String>();
+    final _useValueChanged = Func2<int, String, String>();
     String result;
 
     pump() => tester.pumpWidget(HookBuilder(
           builder: (context) {
-            result = context.useValueChanged(value, useValueChanged.call);
+            result = useValueChanged(value, _useValueChanged.call);
             return Container();
           },
         ));
@@ -20,43 +20,43 @@ void main() {
     final HookElement context = find.byType(HookBuilder).evaluate().first;
 
     expect(result, null);
-    verifyNoMoreInteractions(useValueChanged);
+    verifyNoMoreInteractions(_useValueChanged);
     expect(context.dirty, false);
 
     await pump();
 
     expect(result, null);
-    verifyNoMoreInteractions(useValueChanged);
+    verifyNoMoreInteractions(_useValueChanged);
     expect(context.dirty, false);
 
     value++;
-    when(useValueChanged.call(any, any)).thenReturn('Hello');
+    when(_useValueChanged.call(any, any)).thenReturn('Hello');
     await pump();
 
-    verify(useValueChanged.call(42, null));
+    verify(_useValueChanged.call(42, null));
     expect(result, 'Hello');
-    verifyNoMoreInteractions(useValueChanged);
+    verifyNoMoreInteractions(_useValueChanged);
     expect(context.dirty, false);
 
     await pump();
 
     expect(result, 'Hello');
-    verifyNoMoreInteractions(useValueChanged);
+    verifyNoMoreInteractions(_useValueChanged);
     expect(context.dirty, false);
 
     value++;
-    when(useValueChanged.call(any, any)).thenReturn('Foo');
+    when(_useValueChanged.call(any, any)).thenReturn('Foo');
     await pump();
 
     expect(result, 'Foo');
-    verify(useValueChanged.call(43, 'Hello'));
-    verifyNoMoreInteractions(useValueChanged);
+    verify(_useValueChanged.call(43, 'Hello'));
+    verifyNoMoreInteractions(_useValueChanged);
     expect(context.dirty, false);
 
     await pump();
 
     expect(result, 'Foo');
-    verifyNoMoreInteractions(useValueChanged);
+    verifyNoMoreInteractions(_useValueChanged);
     expect(context.dirty, false);
 
     // dispose
@@ -66,7 +66,7 @@ void main() {
   testWidgets('valueChanged required', (tester) async {
     await tester.pumpWidget(HookBuilder(
       builder: (context) {
-        context.useValueChanged<int, int>(42, null);
+        useValueChanged<int, int>(42, null);
         return Container();
       },
     ));

--- a/test/use_value_listenable_test.dart
+++ b/test/use_value_listenable_test.dart
@@ -8,7 +8,7 @@ void main() {
     await expectPump(
         () => tester.pumpWidget(HookBuilder(
               builder: (context) {
-                context.useValueListenable<void>(null);
+                useValueListenable<void>(null);
                 return Container();
               },
             )),
@@ -20,7 +20,7 @@ void main() {
 
     pump() => tester.pumpWidget(HookBuilder(
           builder: (context) {
-            result = context.useValueListenable(listenable);
+            result = useValueListenable(listenable);
             return Container();
           },
         ));


### PR DESCRIPTION
Make hooks static: `context.useState` becomes `useState`.

This is fine because hooks are inaccessible outside of build

* [x] implementation
* [x] fix documentation