### PR TITLE
NEW: add preserveState to useStream/useFuture

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,14 @@
+## 0.3.0:
+
+- NEW: `useStream` and `useFuture` now have an optional `preserveState` flag.
+  This toggle how these hooks behaves when changing the stream/future:
+  If true (default) they keep the previous value, else they reset to initialState.
+
 ## 0.2.1:
 
 - NEW: `useValueNotifier`, which creates a `ValueNotifier` similarly to `useState`. But without listening it.
-This can be useful to have a more granular rebuild when combined to `useValueListenable`.
-- NEW: `useContext`, which exposes the `BuildContext` of the currently building `HookWidget`. 
+  This can be useful to have a more granular rebuild when combined to `useValueListenable`.
+- NEW: `useContext`, which exposes the `BuildContext` of the currently building `HookWidget`.
 
 ## 0.2.0:
 

--- a/test/use_future_test.dart
+++ b/test/use_future_test.dart
@@ -6,6 +6,51 @@ import 'package:flutter_hooks/flutter_hooks.dart';
 import 'mock.dart';
 
 void main() {
+  testWidgets('default preserve state, changing future keeps previous value',
+      (tester) async {
+    AsyncSnapshot<int> value;
+    Widget Function(BuildContext) builder(Future<int> stream) {
+      return (context) {
+        value = useFuture(stream);
+        return Container();
+      };
+    }
+
+    var future = Future.value(0);
+    await tester.pumpWidget(HookBuilder(builder: builder(future)));
+    expect(value.data, null);
+    await tester.pumpWidget(HookBuilder(builder: builder(future)));
+    expect(value.data, 0);
+
+    future = Future.value(42);
+    await tester.pumpWidget(HookBuilder(builder: builder(future)));
+    expect(value.data, 0);
+    await tester.pumpWidget(HookBuilder(builder: builder(future)));
+    expect(value.data, 42);
+  });
+  testWidgets('If preserveState == false, changing future resets value',
+      (tester) async {
+    AsyncSnapshot<int> value;
+    Widget Function(BuildContext) builder(Future<int> stream) {
+      return (context) {
+        value = useFuture(stream, preserveState: false);
+        return Container();
+      };
+    }
+
+    var future = Future.value(0);
+    await tester.pumpWidget(HookBuilder(builder: builder(future)));
+    expect(value.data, null);
+    await tester.pumpWidget(HookBuilder(builder: builder(future)));
+    expect(value.data, 0);
+
+    future = Future.value(42);
+    await tester.pumpWidget(HookBuilder(builder: builder(future)));
+    expect(value.data, null);
+    await tester.pumpWidget(HookBuilder(builder: builder(future)));
+    expect(value.data, 42);
+  });
+
   Widget Function(BuildContext) snapshotText(Future<String> stream,
       {String initialData}) {
     return (context) {

--- a/test/use_stream_test.dart
+++ b/test/use_stream_test.dart
@@ -8,6 +8,53 @@ import 'mock.dart';
 /// port of [StreamBuilder]
 ///
 void main() {
+  testWidgets('default preserve state, changing stream keeps previous value',
+      (tester) async {
+    AsyncSnapshot<int> value;
+    Widget Function(BuildContext) builder(Stream<int> stream) {
+      return (context) {
+        value = useStream(stream);
+        return Container();
+      };
+    }
+
+    var stream = Stream.fromFuture(Future.value(0));
+    await tester.pumpWidget(HookBuilder(builder: builder(stream)));
+    expect(value.data, null);
+    await tester.pumpWidget(HookBuilder(builder: builder(stream)));
+    expect(value.data, 0);
+
+    stream = Stream.fromFuture(Future.value(42));
+    await tester.pumpWidget(HookBuilder(builder: builder(stream)));
+    expect(value.data, 0);
+    await tester.pumpWidget(HookBuilder(builder: builder(stream)));
+    expect(value.data, 42);
+  });
+  testWidgets('If preserveState == false, changing stream resets value',
+      (tester) async {
+    AsyncSnapshot<int> value;
+    Widget Function(BuildContext) builder(Stream<int> stream) {
+      return (context) {
+        value = useStream(stream, preserveState: false);
+        return Container();
+      };
+    }
+
+    var stream = Stream.fromFuture(Future.value(0));
+    await tester.pumpWidget(HookBuilder(builder: builder(stream)));
+    expect(value.data, null);
+    await tester.pumpWidget(HookBuilder(builder: builder(stream)));
+    expect(value.data, 0);
+
+    stream = Stream.fromFuture(Future.value(42));
+    await tester.pumpWidget(HookBuilder(builder: builder(stream)));
+    expect(value.data, null);
+    await tester.pumpWidget(HookBuilder(builder: builder(stream)));
+    expect(value.data, 42);
+  });
+
+
+  
   Widget Function(BuildContext) snapshotText(Stream<String> stream,
       {String initialData}) {
     return (context) {


### PR DESCRIPTION
This toggle how these hooks behaves when changing the stream/future:
If true (default) they keep the previous value.
Else they reset to initialState.