### PR TITLE
NEW: Better exceptions handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 0.3.0:
 
+- NEW: If a widget throws on the first build or after a hot-reload, next rebuilds can still add/edit hooks until one `build` finishes entirely.
 - NEW: new life-cycle availble on `HookState`: `didBuild`.
 This life-cycle is called synchronously right after `build` method of `HookWidget` finished.
 - NEW: new `reassemble` life-cycle on `HookState`. It is equivalent to `State.ressemble` of statefulwidgets. 

--- a/lib/src/hooks.dart
+++ b/lib/src/hooks.dart
@@ -677,17 +677,19 @@ class _StreamHookState<T> extends HookState<AsyncSnapshot<T>, _StreamHook<T>> {
       current.inState(ConnectionState.none);
 }
 
+typedef Dispose = void Function();
+
 /// A hook for side-effects
 ///
 /// [useEffect] is called synchronously on every [HookWidget.build], unless
 /// [keys] is specified. In which case [useEffect] is called again only if
 /// any value inside [keys] as changed.
-void useEffect(VoidCallback Function() effect, [List keys]) {
+void useEffect(Dispose Function() effect, [List keys]) {
   Hook.use(_EffectHook(effect, keys));
 }
 
 class _EffectHook extends Hook<void> {
-  final VoidCallback Function() effect;
+  final Dispose Function() effect;
 
   const _EffectHook(this.effect, [List keys])
       : assert(effect != null),
@@ -698,7 +700,7 @@ class _EffectHook extends Hook<void> {
 }
 
 class _EffectHookState extends HookState<void, _EffectHook> {
-  VoidCallback disposer;
+  Dispose disposer;
 
   @override
   void initHook() {


### PR DESCRIPTION
If a widget throws on the first build or after a hot-reload
Next rebuilds can still add/edit hooks
until one `build` finishes entirely.

closes #52