### PR TITLE
fix hooks not compiling on recent flutter releases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.4.0:
+
+- Make hooks compatible with newer flutter version. (see https://groups.google.com/forum/#!topic/flutter-announce/hp1RNIgej38)
+
 ## 0.3.0:
 
 - NEW: `usePrevious`, a hook that returns the previous argument it received.

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -7,7 +7,7 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.8"
+    version: "2.2.0"
   boolean_selector:
     dependency: transitive
     description:
@@ -52,7 +52,7 @@ packages:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.3+1"
+    version: "0.12.5"
   meta:
     dependency: transitive
     description:
@@ -73,14 +73,14 @@ packages:
       name: pedantic
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.4.0"
+    version: "1.5.0"
   quiver:
     dependency: transitive
     description:
       name: quiver
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.1"
+    version: "2.0.3"
   shared_preferences:
     dependency: "direct main"
     description:
@@ -99,7 +99,7 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.5.4"
+    version: "1.5.5"
   stack_trace:
     dependency: transitive
     description:
@@ -113,7 +113,7 @@ packages:
       name: stream_channel
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.6.8"
+    version: "2.0.0"
   string_scanner:
     dependency: transitive
     description:
@@ -134,7 +134,7 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.2"
+    version: "0.2.5"
   typed_data:
     dependency: transitive
     description:
@@ -150,5 +150,5 @@ packages:
     source: hosted
     version: "2.0.8"
 sdks:
-  dart: ">=2.1.0 <3.0.0"
-  flutter: ">=0.1.4 <2.0.0"
+  dart: ">=2.2.0 <3.0.0"
+  flutter: ">=1.5.0-pre <2.0.0"

--- a/lib/src/framework.dart
+++ b/lib/src/framework.dart
@@ -325,7 +325,8 @@ This may happen if the call to `Hook.use` is made under some condition.
             exception: exception,
             stack: stack,
             library: 'hooks library',
-            context: 'while calling `didBuild` on ${hook.runtimeType}',
+            context: ErrorDescription(
+                'while calling `didBuild` on ${hook.runtimeType}'),
           ));
         }
       }
@@ -345,7 +346,7 @@ This may happen if the call to `Hook.use` is made under some condition.
             exception: exception,
             stack: stack,
             library: 'hooks library',
-            context: 'while disposing ${hook.runtimeType}',
+            context: ErrorDescription('while disposing ${hook.runtimeType}'),
           ));
         }
       }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -7,7 +7,7 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.8"
+    version: "2.2.0"
   boolean_selector:
     dependency: transitive
     description:
@@ -45,7 +45,7 @@ packages:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.3+1"
+    version: "0.12.5"
   meta:
     dependency: transitive
     description:
@@ -73,14 +73,14 @@ packages:
       name: pedantic
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.4.0"
+    version: "1.5.0"
   quiver:
     dependency: transitive
     description:
       name: quiver
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.1"
+    version: "2.0.3"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -92,7 +92,7 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.5.4"
+    version: "1.5.5"
   stack_trace:
     dependency: transitive
     description:
@@ -106,7 +106,7 @@ packages:
       name: stream_channel
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.6.8"
+    version: "2.0.0"
   string_scanner:
     dependency: transitive
     description:
@@ -127,7 +127,7 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.2"
+    version: "0.2.5"
   typed_data:
     dependency: transitive
     description:
@@ -143,4 +143,5 @@ packages:
     source: hosted
     version: "2.0.8"
 sdks:
-  dart: ">=2.1.0 <3.0.0"
+  dart: ">=2.2.0 <3.0.0"
+  flutter: ">=1.5.0-pre <=2.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,6 +7,7 @@ version: 0.3.0
 
 environment:
   sdk: ">=2.0.0 <3.0.0"
+  flutter: ">= 1.5.0-pre <= 2.0.0"
 
 dependencies:
   flutter:


### PR DESCRIPTION
This solve a recent breaking change:
https://groups.google.com/forum/#!topic/flutter-announce/hp1RNIgej38

closes #77