### PR TITLE
ErrorDescription gone in Flutter 1.5.8

### DIFF
--- a/lib/src/framework.dart
+++ b/lib/src/framework.dart
@@ -325,8 +325,7 @@ This may happen if the call to `Hook.use` is made under some condition.
             exception: exception,
             stack: stack,
             library: 'hooks library',
-            context: ErrorDescription(
-                'while calling `didBuild` on ${hook.runtimeType}'),
+            context: 'while calling `didBuild` on ${hook.runtimeType}',
           ));
         }
       }
@@ -346,7 +345,7 @@ This may happen if the call to `Hook.use` is made under some condition.
             exception: exception,
             stack: stack,
             library: 'hooks library',
-            context: ErrorDescription('while disposing ${hook.runtimeType}'),
+            context: 'while disposing ${hook.runtimeType}',
           ));
         }
       }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -7,7 +7,7 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.2.0"
+    version: "2.1.0"
   boolean_selector:
     dependency: transitive
     description:
@@ -80,7 +80,7 @@ packages:
       name: quiver
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.3"
+    version: "2.0.2"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -127,7 +127,7 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.5"
+    version: "0.2.4"
   typed_data:
     dependency: transitive
     description:
@@ -144,4 +144,4 @@ packages:
     version: "2.0.8"
 sdks:
   dart: ">=2.2.0 <3.0.0"
-  flutter: ">=1.5.0-pre <=2.0.0"
+  flutter: ">=1.5.8-pre <=2.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,11 +3,11 @@ description: A flutter implementation of React hooks. It adds a new kind of widg
 homepage: https://github.com/rrousselGit/flutter_hooks
 author: Remi Rousselet <darky12s@gmail.com>
 
-version: 0.4.0
+version: 0.4.1
 
 environment:
   sdk: ">=2.0.0 <3.0.0"
-  flutter: ">= 1.5.0-pre <= 2.0.0"
+  flutter: ">= 1.5.8-pre <= 2.0.0"
 
 dependencies:
   flutter:


### PR DESCRIPTION
I switched to the Flutter `dev` channel today and upgraded all my packages, including `flutter_bloc` which depends on this package. It seems the `ErrorDescription` class has been removed in Flutter >= 1.5.8. 