### PR TITLE
reverse dispose call orders

### DIFF
--- a/lib/src/framework.dart
+++ b/lib/src/framework.dart
@@ -337,7 +337,7 @@ This may happen if the call to `Hook.use` is made under some condition.
   void unmount() {
     super.unmount();
     if (_hooks != null) {
-      for (final hook in _hooks) {
+      for (final hook in _hooks.reversed) {
         try {
           hook.dispose();
         } catch (exception, stack) {

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -7,7 +7,7 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.2.0"
+    version: "2.1.0"
   boolean_selector:
     dependency: transitive
     description:
@@ -80,7 +80,7 @@ packages:
       name: quiver
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.3"
+    version: "2.0.2"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -127,7 +127,7 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.5"
+    version: "0.2.4"
   typed_data:
     dependency: transitive
     description:
@@ -144,4 +144,4 @@ packages:
     version: "2.0.8"
 sdks:
   dart: ">=2.2.0 <3.0.0"
-  flutter: ">=1.5.0-pre <=2.0.0"
+  flutter: ">=1.0.0 <1.5.8"

--- a/test/hook_widget_test.dart
+++ b/test/hook_widget_test.dart
@@ -96,6 +96,24 @@ void main() {
     expect(find.text('1'), findsOneWidget);
   });
 
+  testWidgets('hooks are disposed in reverse order when widget is unmounted',
+      (tester) async {
+    final dispose = Func0<void>();
+    final dispose2 = Func0<void>();
+    await tester.pumpWidget(HookBuilder(builder: (_) {
+      Hook.use(HookTest<int>(dispose: dispose));
+      Hook.use(HookTest<String>(dispose: dispose2));
+      return Container();
+    }));
+
+    await tester.pumpWidget(Container());
+
+    verifyInOrder([
+      dispose2(),
+      dispose(),
+    ]);
+  });
+
   testWidgets('HookElement exposes an immutable list of hooks', (tester) async {
     await tester.pumpWidget(HookBuilder(builder: (_) {
       Hook.use(HookTest<int>());
@@ -516,10 +534,8 @@ void main() {
 
     expect(tester.takeException(), 24);
 
-    verifyInOrder([
-      dispose.call(),
-      dispose2.call(),
-    ]);
+    verify(dispose()).called(1);
+    verify(dispose2()).called(1);
   });
 
   testWidgets('hook update with same instance do not call didUpdateHook',


### PR DESCRIPTION
### Feature

- [x] dispose hooks in reverse order when `HookWidget` is unmounted
- [ ] dispose hooks in reverse order when hot-reload cannot complete

### related issues:

#81 
