### PR TITLE
Add hook to build a text controller

### DIFF
--- a/lib/src/hooks.dart
+++ b/lib/src/hooks.dart
@@ -4,8 +4,10 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/scheduler.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_hooks/src/framework.dart';
-part 'async.dart';
+
 part 'animation.dart';
+part 'async.dart';
+part 'listenable.dart';
 part 'misc.dart';
 part 'primitives.dart';
-part 'listenable.dart';
+part 'text_controller.dart';

--- a/lib/src/text_controller.dart
+++ b/lib/src/text_controller.dart
@@ -18,21 +18,39 @@ class _TextEditingControllerHookCreator {
   }
 }
 
-/// Functions to create a text editing controller, either via an initial
-/// text or an initial [TextEditingValue].
+/// Creates a [TextEditingController], either via an initial text or an initial
+/// [TextEditingValue].
 ///
 /// To use a [TextEditingController] with an optional initial text, use
-/// [_TextEditingControllerHookCreator.call]:
 /// ```dart
 /// final controller = useTextEditingController(text: 'initial text');
 /// ```
 ///
 /// To use a [TextEditingController] with an optional inital value, use
-/// [_TextEditingControllerHookCreator.fromValue]:
 /// ```dart
 /// final controller = useTextEditingController
 ///   .fromValue(TextEditingValue.empty);
 /// ```
+///
+/// Changing the text or initial value after the widget has been built has no
+/// effect whatsoever. To update the value in a callback, for instance after a
+/// button was pressed, use the [TextEditingController.text] or
+/// [TextEditingController.value] setters. To have the [TextEditingController]
+/// reflect changing values, you can use [useEffect]. This example will update
+/// the [TextEditingController.text] whenever a provided [ValueListenable]
+/// changes:
+/// ```dart
+/// final controller = useTextEditingController();
+/// final update = useValueListenable(myTextControllerUpdates);
+///
+/// useEffect(() {
+///   controller.text = update;
+///   return null; // we don't need to have a special dispose logic
+/// }, [update]);
+/// ```
+///
+/// See also:
+/// - [TextEditingController], which this hook creates.
 const useTextEditingController = _TextEditingControllerHookCreator();
 
 class _TextEditingControllerHook extends Hook<TextEditingController> {
@@ -49,7 +67,7 @@ class _TextEditingControllerHook extends Hook<TextEditingController> {
         super(keys: keys);
 
   @override
-  HookState<TextEditingController, _TextEditingControllerHook> createState() {
+  _TextEditingControllerHookState createState() {
     return _TextEditingControllerHookState();
   }
 }
@@ -58,20 +76,17 @@ class _TextEditingControllerHookState
     extends HookState<TextEditingController, _TextEditingControllerHook> {
   TextEditingController _controller;
 
-  TextEditingController _constructController() {
-    if (hook.initialText != null) {
-      return TextEditingController(text: hook.initialText);
-    } else if (hook.initialValue != null) {
-      return TextEditingController.fromValue(hook.initialValue);
+  @override
+  void initHook() {
+    if (hook.initialValue != null) {
+      _controller = TextEditingController.fromValue(hook.initialValue);
     } else {
-      return TextEditingController();
+      _controller = TextEditingController(text: hook.initialText);
     }
   }
 
   @override
-  TextEditingController build(BuildContext context) {
-    return _controller ??= _constructController();
-  }
+  TextEditingController build(BuildContext context) => _controller;
 
   @override
   void dispose() => _controller?.dispose();

--- a/lib/src/text_controller.dart
+++ b/lib/src/text_controller.dart
@@ -1,0 +1,59 @@
+part of 'hooks.dart';
+
+/// Creates an [TextEditingController] that will be disposed automatically.
+///
+/// The optional [initialText] parameter can be used to set the initial
+/// [TextEditingController.text]. Similarly, [initialValue] can be used to set
+/// the initial [TextEditingController.value]. It is invalid to set both
+/// [initialText] and [initialValue].
+/// When this hook is re-used with different values of [initialText] or
+/// [initialValue], the underlying [TextEditingController] will _not_ be
+/// updated. Set values on [TextEditingController.text] or
+/// [TextEditingController.value] directly to change the text or selection,
+/// respectively.
+TextEditingController useTextEditingController(
+    {String initialText, TextEditingValue initialValue, List<Object> keys}) {
+  return Hook.use(_TextEditingControllerHook(initialText, initialValue, keys));
+}
+
+class _TextEditingControllerHook extends Hook<TextEditingController> {
+  final String initialText;
+  final TextEditingValue initialValue;
+
+  _TextEditingControllerHook(this.initialText, this.initialValue,
+      [List<Object> keys])
+      : assert(
+          initialText == null || initialValue == null,
+          "initialText and intialValue can't both be set on a call to "
+          'useTextEditingController!',
+        ),
+        super(keys: keys);
+
+  @override
+  HookState<TextEditingController, _TextEditingControllerHook> createState() {
+    return _TextEditingControllerHookState();
+  }
+}
+
+class _TextEditingControllerHookState
+    extends HookState<TextEditingController, _TextEditingControllerHook> {
+  TextEditingController _controller;
+
+  TextEditingController _constructController() {
+    if (hook.initialText != null) {
+      return TextEditingController(text: hook.initialText);
+    } else if (hook.initialValue != null) {
+      return TextEditingController.fromValue(hook.initialValue);
+    } else {
+      return TextEditingController();
+    }
+  }
+
+  @override
+  TextEditingController build(BuildContext context) {
+    return _controller ??= _constructController();
+  }
+
+  @override
+  void dispose() => _controller?.dispose();
+}

--- a/lib/src/text_controller.dart
+++ b/lib/src/text_controller.dart
@@ -1,20 +1,39 @@
 part of 'hooks.dart';
 
-/// Creates an [TextEditingController] that will be disposed automatically.
-///
-/// The optional [initialText] parameter can be used to set the initial
-/// [TextEditingController.text]. Similarly, [initialValue] can be used to set
-/// the initial [TextEditingController.value]. It is invalid to set both
-/// [initialText] and [initialValue].
-/// When this hook is re-used with different values of [initialText] or
-/// [initialValue], the underlying [TextEditingController] will _not_ be
-/// updated. Set values on [TextEditingController.text] or
-/// [TextEditingController.value] directly to change the text or selection,
-/// respectively.
-TextEditingController useTextEditingController(
-    {String initialText, TextEditingValue initialValue, List<Object> keys}) {
-  return Hook.use(_TextEditingControllerHook(initialText, initialValue, keys));
+class _TextEditingControllerHookCreator {
+  const _TextEditingControllerHookCreator();
+
+  /// Creates a [TextEditingController] that will be disposed automatically.
+  ///
+  /// The [text] parameter can be used to set the initial value of the
+  /// controller.
+  TextEditingController call({String text, List<Object> keys}) {
+    return Hook.use(_TextEditingControllerHook(text, null, keys));
+  }
+
+  /// Creates a [TextEditingController] from the initial [value] that will
+  /// be disposed automatically.
+  TextEditingController fromValue(TextEditingValue value, [List<Object> keys]) {
+    return Hook.use(_TextEditingControllerHook(null, value, keys));
+  }
 }
+
+/// Functions to create a text editing controller, either via an initial
+/// text or an initial [TextEditingValue].
+///
+/// To use a [TextEditingController] with an optional initial text, use
+/// [_TextEditingControllerHookCreator.call]:
+/// ```dart
+/// final controller = useTextEditingController(text: 'initial text');
+/// ```
+///
+/// To use a [TextEditingController] with an optional inital value, use
+/// [_TextEditingControllerHookCreator.fromValue]:
+/// ```dart
+/// final controller = useTextEditingController
+///   .fromValue(TextEditingValue.empty);
+/// ```
+const useTextEditingController = _TextEditingControllerHookCreator();
 
 class _TextEditingControllerHook extends Hook<TextEditingController> {
   final String initialText;

--- a/test/use_text_editing_controller_test.dart
+++ b/test/use_text_editing_controller_test.dart
@@ -6,21 +6,6 @@ import 'package:flutter_test/flutter_test.dart';
 import 'mock.dart';
 
 void main() {
-  testWidgets('throws when both initial text and value is set', (tester) {
-    return expectPump(
-      () => tester.pumpWidget(HookBuilder(
-        builder: (context) {
-          useTextEditingController(
-            initialText: 'foo',
-            initialValue: TextEditingValue.empty,
-          );
-          return Container();
-        },
-      )),
-      throwsAssertionError,
-    );
-  });
-
   testWidgets('useTextEditingController returns a controller', (tester) async {
     TextEditingController controller;
 
@@ -42,12 +27,12 @@ void main() {
     }));
   });
 
-  testWidgets('respects initialText property', (tester) async {
+  testWidgets('respects initial text property', (tester) async {
     TextEditingController controller;
 
     await tester.pumpWidget(HookBuilder(
       builder: (context) {
-        controller = useTextEditingController(initialText: 'hello hooks');
+        controller = useTextEditingController(text: 'hello hooks');
         return Container();
       },
     ));
@@ -55,14 +40,14 @@ void main() {
     expect(controller.text, 'hello hooks');
   });
 
-  testWidgets('respects initialValue property', (tester) async {
+  testWidgets('respects initial value property', (tester) async {
     const value = TextEditingValue(
         text: 'foo', selection: TextSelection.collapsed(offset: 2));
     TextEditingController controller;
 
     await tester.pumpWidget(HookBuilder(
       builder: (context) {
-        controller = useTextEditingController(initialValue: value);
+        controller = useTextEditingController.fromValue(value);
         return Container();
       },
     ));

--- a/test/use_text_editing_controller_test.dart
+++ b/test/use_text_editing_controller_test.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/foundation.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_hooks/src/framework.dart';
 import 'package:flutter_hooks/src/hooks.dart';
@@ -7,17 +8,26 @@ import 'mock.dart';
 
 void main() {
   testWidgets('useTextEditingController returns a controller', (tester) async {
+    final rebuilder = ValueNotifier(0);
     TextEditingController controller;
 
     await tester.pumpWidget(HookBuilder(
       builder: (context) {
         controller = useTextEditingController();
+        useValueListenable(rebuilder);
         return Container();
       },
     ));
 
     expect(controller, isNotNull);
     controller.addListener(() {});
+
+    // rebuild hook
+    final firstController = controller;
+    rebuilder.notifyListeners();
+    await tester.pumpAndSettle();
+    expect(identical(controller, firstController), isTrue,
+        reason: 'Controllers should be identical after rebuilds');
 
     // pump another widget so that the old one gets disposed
     await tester.pumpWidget(Container());
@@ -28,30 +38,51 @@ void main() {
   });
 
   testWidgets('respects initial text property', (tester) async {
+    final rebuilder = ValueNotifier(0);
     TextEditingController controller;
+    const initialText = 'hello hooks';
+    var targetText = initialText;
 
     await tester.pumpWidget(HookBuilder(
       builder: (context) {
-        controller = useTextEditingController(text: 'hello hooks');
+        controller = useTextEditingController(text: targetText);
+        useValueListenable(rebuilder);
         return Container();
       },
     ));
 
-    expect(controller.text, 'hello hooks');
+    expect(controller.text, targetText);
+
+    // change text and rebuild - the value of the controler shouldn't change
+    targetText = "can't see me!";
+    rebuilder.notifyListeners();
+    await tester.pumpAndSettle();
+    expect(controller.text, initialText);
   });
 
   testWidgets('respects initial value property', (tester) async {
-    const value = TextEditingValue(
-        text: 'foo', selection: TextSelection.collapsed(offset: 2));
+    final rebuilder = ValueNotifier(0);
+    const initialValue = TextEditingValue(
+      text: 'foo',
+      selection: TextSelection.collapsed(offset: 2),
+    );
+    var targetValue = initialValue;
     TextEditingController controller;
 
     await tester.pumpWidget(HookBuilder(
       builder: (context) {
-        controller = useTextEditingController.fromValue(value);
+        controller = useTextEditingController.fromValue(targetValue);
+        useValueListenable(rebuilder);
         return Container();
       },
     ));
 
-    expect(controller.value, value);
+    expect(controller.value, targetValue);
+
+    // similar to above - the value should not change after a rebuild
+    targetValue = const TextEditingValue(text: 'another');
+    rebuilder.notifyListeners();
+    await tester.pumpAndSettle();
+    expect(controller.value, initialValue);
   });
 }

--- a/test/use_text_editing_controller_test.dart
+++ b/test/use_text_editing_controller_test.dart
@@ -1,0 +1,72 @@
+import 'package:flutter/widgets.dart';
+import 'package:flutter_hooks/src/framework.dart';
+import 'package:flutter_hooks/src/hooks.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'mock.dart';
+
+void main() {
+  testWidgets('throws when both initial text and value is set', (tester) {
+    return expectPump(
+      () => tester.pumpWidget(HookBuilder(
+        builder: (context) {
+          useTextEditingController(
+            initialText: 'foo',
+            initialValue: TextEditingValue.empty,
+          );
+          return Container();
+        },
+      )),
+      throwsAssertionError,
+    );
+  });
+
+  testWidgets('useTextEditingController returns a controller', (tester) async {
+    TextEditingController controller;
+
+    await tester.pumpWidget(HookBuilder(
+      builder: (context) {
+        controller = useTextEditingController();
+        return Container();
+      },
+    ));
+
+    expect(controller, isNotNull);
+    controller.addListener(() {});
+
+    // pump another widget so that the old one gets disposed
+    await tester.pumpWidget(Container());
+
+    expect(() => controller.addListener(null), throwsA((FlutterError error) {
+      return error.message.contains('disposed');
+    }));
+  });
+
+  testWidgets('respects initialText property', (tester) async {
+    TextEditingController controller;
+
+    await tester.pumpWidget(HookBuilder(
+      builder: (context) {
+        controller = useTextEditingController(initialText: 'hello hooks');
+        return Container();
+      },
+    ));
+
+    expect(controller.text, 'hello hooks');
+  });
+
+  testWidgets('respects initialValue property', (tester) async {
+    const value = TextEditingValue(
+        text: 'foo', selection: TextSelection.collapsed(offset: 2));
+    TextEditingController controller;
+
+    await tester.pumpWidget(HookBuilder(
+      builder: (context) {
+        controller = useTextEditingController(initialValue: value);
+        return Container();
+      },
+    ));
+
+    expect(controller.value, value);
+  });
+}


### PR DESCRIPTION
This PR adds the `useTextEditingController` hook function, which can be used to construct a text editing controller with an optional initial text or `TextEditingValue`.

Fixes #40