### PR TITLE
Fix Existing hooks link on Pub

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.8.0+1
+
+- Fixed link to "Existing hooks" in `README.md`.
+
 ## 0.8.0:
 
 Added `useFocusNode`

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ But you're probably thinking:
 
 > Where did all the logic go?
 
-That logic moved into `useAnimationController`, a function included directly in this library (see https://github.com/rrousselGit/flutter_hooks#existing-hooks). It is what we call a _Hook_.
+That logic moved into `useAnimationController`, a function included directly in this library (see [Existing hooks](https://github.com/rrousselGit/flutter_hooks#existing-hooks)). It is what we call a _Hook_.
 
 Hooks are a new kind of objects with some specificities:
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ description: A flutter implementation of React hooks. It adds a new kind of widg
 homepage: https://github.com/rrousselGit/flutter_hooks
 author: Remi Rousselet <darky12s@gmail.com>
 
-version: 0.8.0
+version: 0.8.0+1
 
 environment:
   sdk: ">=2.7.0 <3.0.0"


### PR DESCRIPTION
If you click on the current link in that section on Pub, it will *not* work. It will direct you to `https://github.com/rrousselGit/flutter_hooks#existing-hooks)` instead of `https://github.com/rrousselGit/flutter_hooks#existing-hooks`, which will not *jump* to the correct heading.  
On GitHub it works, but [on the Pub page](https://pub.dev/packages/flutter_hooks#motivation), it does not work.

I took this opportunity to shorten the link by giving it an alias.  
You could instead also link to it like this: `[https://github.com/rrousselGit/flutter_hooks#existing-hooks](https://github.com/rrousselGit/flutter_hooks#existing-hooks)`. This would both fix the link and retain the old look, however, I do not think that this is desirable.