### PR TITLE
Migrate all use* methods to extension methods on Hookable

### DIFF
--- a/example/lib/custom_hook_function.dart
+++ b/example/lib/custom_hook_function.dart
@@ -31,17 +31,19 @@ class CustomHookFunctionExample extends HookWidget {
   }
 }
 
-/// A custom hook that wraps the useState hook to add logging. Hooks can be
-/// composed -- meaning you can use hooks within hooks!
-ValueNotifier<T> useLoggedState<T>([T initialData]) {
-  // First, call the useState hook. It will create a ValueNotifier for you that
-  // rebuilds the Widget whenever the value changes.
-  final result = useState<T>(initialData);
+extension UseLoggedStateHook on Hookable {
+  /// A custom hook that wraps the useState hook to add logging. Hooks can be
+  /// composed -- meaning you can use hooks within hooks!
+  ValueNotifier<T> useLoggedState<T>([T initialData]) {
+    // First, call the useState hook. It will create a ValueNotifier for you that
+    // rebuilds the Widget whenever the value changes.
+    final result = useState<T>(initialData);
 
-  // Next, call the useValueChanged hook to print the state whenever it changes
-  useValueChanged<T, void>(result.value, (_, __) {
-    print(result.value);
-  });
+    // Next, call the useValueChanged hook to print the state whenever it changes
+    useValueChanged<T, void>(result.value, (_, __) {
+      print(result.value);
+    });
 
-  return result;
+    return result;
+  }
 }

--- a/example/lib/use_effect.dart
+++ b/example/lib/use_effect.dart
@@ -28,7 +28,7 @@ class CustomHookExample extends HookWidget {
         // smaller portion of the Widget tree is rebuilt when the stream emits a
         // new value
         child: HookBuilder(
-          builder: (context) {
+          builder: (context, _) {
             final AsyncSnapshot<int> count = useStream(countController.stream);
 
             return !count.hasData
@@ -44,52 +44,54 @@ class CustomHookExample extends HookWidget {
   }
 }
 
+extension on Hookable {
 // A custom hook that will read and write values to local storage using the
 // SharedPreferences package.
-StreamController<int> _useLocalStorageInt(
-  String key, {
-  int defaultValue = 0,
-}) {
-  // Custom hooks can use additional hooks internally!
-  final controller = useStreamController<int>(keys: [key]);
+  StreamController<int> _useLocalStorageInt(
+    String key, {
+    int defaultValue = 0,
+  }) {
+    // Custom hooks can use additional hooks internally!
+    final controller = useStreamController<int>(keys: [key]);
 
-  // Pass a callback to the useEffect hook. This function should be called on
-  // first build and every time the controller or key changes
-  useEffect(
-    () {
-      // Listen to the StreamController, and when a value is added, store it
-      // using SharedPrefs.
-      final sub = controller.stream.listen((data) async {
-        final prefs = await SharedPreferences.getInstance();
-        await prefs.setInt(key, data);
-      });
-      // Unsubscribe when the widget is disposed
-      // or on controller/key change
-      return sub.cancel;
-    },
-    // Pass the controller and key to the useEffect hook. This will ensure the
-    // useEffect hook is only called the first build or when one of the the
-    // values changes.
-    [controller, key],
-  );
+    // Pass a callback to the useEffect hook. This function should be called on
+    // first build and every time the controller or key changes
+    useEffect(
+      () {
+        // Listen to the StreamController, and when a value is added, store it
+        // using SharedPrefs.
+        final sub = controller.stream.listen((data) async {
+          final prefs = await SharedPreferences.getInstance();
+          await prefs.setInt(key, data);
+        });
+        // Unsubscribe when the widget is disposed
+        // or on controller/key change
+        return sub.cancel;
+      },
+      // Pass the controller and key to the useEffect hook. This will ensure the
+      // useEffect hook is only called the first build or when one of the the
+      // values changes.
+      [controller, key],
+    );
 
-  // Load the initial value from local storage and add it as the initial value
-  // to the controller
-  useEffect(
-    () {
-      SharedPreferences.getInstance().then((prefs) async {
-        final int valueFromStorage = prefs.getInt(key);
-        controller.add(valueFromStorage ?? defaultValue);
-      }).catchError(controller.addError);
-      return null;
-    },
-    // Pass the controller and key to the useEffect hook. This will ensure the
-    // useEffect hook is only called the first build or when one of the the
-    // values changes.
-    [controller, key],
-  );
+    // Load the initial value from local storage and add it as the initial value
+    // to the controller
+    useEffect(
+      () {
+        SharedPreferences.getInstance().then((prefs) async {
+          final int valueFromStorage = prefs.getInt(key);
+          controller.add(valueFromStorage ?? defaultValue);
+        }).catchError(controller.addError);
+        return null;
+      },
+      // Pass the controller and key to the useEffect hook. This will ensure the
+      // useEffect hook is only called the first build or when one of the the
+      // values changes.
+      [controller, key],
+    );
 
-  // Finally, return the StreamController. This allows users to add values from
-  // the Widget layer and listen to the stream for changes.
-  return controller;
+    // Finally, return the StreamController. This allows users to add values from
+    // the Widget layer and listen to the stream for changes.
+    return controller;
+  }
 }

--- a/example/lib/use_stream.dart
+++ b/example/lib/use_stream.dart
@@ -18,12 +18,12 @@ class UseStreamExample extends StatelessWidget {
         // Widget to limit rebuilds to this section of the app, rather than
         // marking the entire UseStreamExample as a HookWidget!
         child: HookBuilder(
-          builder: (context) {
+          builder: (context, h) {
             // First, create and cache a Stream with the `useMemoized` hook.
             // This hook allows you to create an Object (such as a Stream or
             // Future) the first time this builder function is invoked without
             // recreating it on each subsequent build!
-            final stream = useMemoized(
+            final stream = h.useMemoized(
               () => Stream<int>.periodic(
                   const Duration(seconds: 1), (i) => i + 1),
             );
@@ -31,7 +31,7 @@ class UseStreamExample extends StatelessWidget {
             // Stream. This triggers a rebuild whenever a new value is emitted.
             //
             // Like normal StreamBuilders, it returns the current AsyncSnapshot.
-            final snapshot = useStream(stream);
+            final snapshot = h.useStream(stream);
 
             // Finally, use the data from the Stream to render a text Widget.
             // If no data is available, fallback to a default value.

--- a/lib/src/animation.dart
+++ b/lib/src/animation.dart
@@ -1,13 +1,15 @@
 part of 'hooks.dart';
 
-/// Subscribes to an [Animation] and return its value.
-///
-/// See also:
-///   * [Animation]
-///   * [useValueListenable], [useListenable], [useStream]
-T useAnimation<T>(Animation<T> animation) {
-  use(_UseAnimationHook(animation));
-  return animation.value;
+extension UseAnimationHook on Hookable {
+  /// Subscribes to an [Animation] and return its value.
+  ///
+  /// See also:
+  ///   * [Animation]
+  ///   * [useValueListenable], [useListenable], [useStream]
+  T useAnimation<T>(Animation<T> animation) {
+    use(_UseAnimationHook(animation));
+    return animation.value;
+  }
 }
 
 class _UseAnimationHook extends _ListenableHook {
@@ -27,43 +29,45 @@ class _UseAnimationStateHook extends _ListenableStateHook {
   Object get debugValue => (hook.listenable as Animation).value;
 }
 
-/// Creates an [AnimationController] automatically disposed.
-///
-/// If no [vsync] is provided, the [TickerProvider] is implicitly obtained using [useSingleTickerProvider].
-/// If a [vsync] is specified, changing the instance of [vsync] will result in a call to [AnimationController.resync].
-/// It is not possible to switch between implicit and explicit [vsync].
-///
-/// Changing the [duration] parameter automatically updates [AnimationController.duration].
-///
-/// [initialValue], [lowerBound], [upperBound] and [debugLabel] are ignored after the first call.
-///
-/// See also:
-///   * [AnimationController], the created object.
-///   * [useAnimation], to listen to the created [AnimationController].
-AnimationController useAnimationController({
-  Duration duration,
-  String debugLabel,
-  double initialValue = 0,
-  double lowerBound = 0,
-  double upperBound = 1,
-  TickerProvider vsync,
-  AnimationBehavior animationBehavior = AnimationBehavior.normal,
-  List<Object> keys,
-}) {
-  vsync ??= useSingleTickerProvider(keys: keys);
+extension UseAnimationControllerHook on Hookable {
+  /// Creates an [AnimationController] automatically disposed.
+  ///
+  /// If no [vsync] is provided, the [TickerProvider] is implicitly obtained using [useSingleTickerProvider].
+  /// If a [vsync] is specified, changing the instance of [vsync] will result in a call to [AnimationController.resync].
+  /// It is not possible to switch between implicit and explicit [vsync].
+  ///
+  /// Changing the [duration] parameter automatically updates [AnimationController.duration].
+  ///
+  /// [initialValue], [lowerBound], [upperBound] and [debugLabel] are ignored after the first call.
+  ///
+  /// See also:
+  ///   * [AnimationController], the created object.
+  ///   * [useAnimation], to listen to the created [AnimationController].
+  AnimationController useAnimationController({
+    Duration duration,
+    String debugLabel,
+    double initialValue = 0,
+    double lowerBound = 0,
+    double upperBound = 1,
+    TickerProvider vsync,
+    AnimationBehavior animationBehavior = AnimationBehavior.normal,
+    List<Object> keys,
+  }) {
+    vsync ??= useSingleTickerProvider(keys: keys);
 
-  return use(
-    _AnimationControllerHook(
-      duration: duration,
-      debugLabel: debugLabel,
-      initialValue: initialValue,
-      lowerBound: lowerBound,
-      upperBound: upperBound,
-      vsync: vsync,
-      animationBehavior: animationBehavior,
-      keys: keys,
-    ),
-  );
+    return use(
+      _AnimationControllerHook(
+        duration: duration,
+        debugLabel: debugLabel,
+        initialValue: initialValue,
+        lowerBound: lowerBound,
+        upperBound: upperBound,
+        vsync: vsync,
+        animationBehavior: animationBehavior,
+        keys: keys,
+      ),
+    );
+  }
 }
 
 class _AnimationControllerHook extends Hook<AnimationController> {
@@ -144,16 +148,18 @@ class _AnimationControllerHookState
   String get debugLabel => 'useAnimationController';
 }
 
-/// Creates a single usage [TickerProvider].
-///
-/// See also:
-///  * [SingleTickerProviderStateMixin]
-TickerProvider useSingleTickerProvider({List<Object> keys}) {
-  return use(
-    keys != null
-        ? _SingleTickerProviderHook(keys)
-        : const _SingleTickerProviderHook(),
-  );
+extension UseSingleTickerProviderHook on Hookable {
+  /// Creates a single usage [TickerProvider].
+  ///
+  /// See also:
+  ///  * [SingleTickerProviderStateMixin]
+  TickerProvider useSingleTickerProvider({List<Object> keys}) {
+    return use(
+      keys != null
+          ? _SingleTickerProviderHook(keys)
+          : const _SingleTickerProviderHook(),
+    );
+  }
 }
 
 class _SingleTickerProviderHook extends Hook<TickerProvider> {

--- a/lib/src/async.dart
+++ b/lib/src/async.dart
@@ -1,17 +1,19 @@
 part of 'hooks.dart';
 
-/// Subscribes to a [Future] and return its current state in an [AsyncSnapshot].
-///
-/// * [preserveState] defines if the current value should be preserved when changing
-/// the [Future] instance.
-///
-/// See also:
-///   * [Future], the listened object.
-///   * [useStream], similar to [useFuture] but for [Stream].
-AsyncSnapshot<T> useFuture<T>(Future<T> future,
-    {T initialData, bool preserveState = true}) {
-  return use(_FutureHook(future,
-      initialData: initialData, preserveState: preserveState));
+extension UseFutureHook on Hookable {
+  /// Subscribes to a [Future] and return its current state in an [AsyncSnapshot].
+  ///
+  /// * [preserveState] defines if the current value should be preserved when changing
+  /// the [Future] instance.
+  ///
+  /// See also:
+  ///   * [Future], the listened object.
+  ///   * [useStream], similar to [useFuture] but for [Stream].
+  AsyncSnapshot<T> useFuture<T>(Future<T> future,
+      {T initialData, bool preserveState = true}) {
+    return use(_FutureHook(future,
+        initialData: initialData, preserveState: preserveState));
+  }
 }
 
 class _FutureHook<T> extends Hook<AsyncSnapshot<T>> {
@@ -99,18 +101,20 @@ class _FutureStateHook<T> extends HookState<AsyncSnapshot<T>, _FutureHook<T>> {
   Object get debugValue => _snapshot;
 }
 
-/// Subscribes to a [Stream] and return its current state in an [AsyncSnapshot].
-///
-/// See also:
-///   * [Stream], the object listened.
-///   * [useFuture], similar to [useStream] but for [Future].
-AsyncSnapshot<T> useStream<T>(Stream<T> stream,
-    {T initialData, bool preserveState = true}) {
-  return use(_StreamHook(
-    stream,
-    initialData: initialData,
-    preserveState: preserveState,
-  ));
+extension UseStreamHook on Hookable {
+  /// Subscribes to a [Stream] and return its current state in an [AsyncSnapshot].
+  ///
+  /// See also:
+  ///   * [Stream], the object listened.
+  ///   * [useFuture], similar to [useStream] but for [Future].
+  AsyncSnapshot<T> useStream<T>(Stream<T> stream,
+      {T initialData, bool preserveState = true}) {
+    return use(_StreamHook(
+      stream,
+      initialData: initialData,
+      preserveState: preserveState,
+    ));
+  }
 }
 
 class _StreamHook<T> extends Hook<AsyncSnapshot<T>> {
@@ -212,22 +216,24 @@ class _StreamHookState<T> extends HookState<AsyncSnapshot<T>, _StreamHook<T>> {
   String get debugLabel => 'useStream';
 }
 
-/// Creates a [StreamController] automatically disposed.
-///
-/// See also:
-///   * [StreamController], the created object
-///   * [useStream], to listen to the created [StreamController]
-StreamController<T> useStreamController<T>(
-    {bool sync = false,
-    VoidCallback onListen,
-    VoidCallback onCancel,
-    List<Object> keys}) {
-  return use(_StreamControllerHook(
-    onCancel: onCancel,
-    onListen: onListen,
-    sync: sync,
-    keys: keys,
-  ));
+extension UseStreamControllerHook on Hookable {
+  /// Creates a [StreamController] automatically disposed.
+  ///
+  /// See also:
+  ///   * [StreamController], the created object
+  ///   * [useStream], to listen to the created [StreamController]
+  StreamController<T> useStreamController<T>(
+      {bool sync = false,
+      VoidCallback onListen,
+      VoidCallback onCancel,
+      List<Object> keys}) {
+    return use(_StreamControllerHook(
+      onCancel: onCancel,
+      onListen: onListen,
+      sync: sync,
+      keys: keys,
+    ));
+  }
 }
 
 class _StreamControllerHook<T> extends Hook<StreamController<T>> {

--- a/lib/src/focus.dart
+++ b/lib/src/focus.dart
@@ -1,23 +1,25 @@
 part of 'hooks.dart';
 
-/// Creates and dispose of a [FocusNode].
-///
-/// See also:
-/// - [FocusNode]
-FocusNode useFocusNode({
-  String debugLabel,
-  FocusOnKeyCallback onKey,
-  bool skipTraversal = false,
-  bool canRequestFocus = true,
-  bool descendantsAreFocusable = true,
-}) =>
-    use(_FocusNodeHook(
-      debugLabel: debugLabel,
-      onKey: onKey,
-      skipTraversal: skipTraversal,
-      canRequestFocus: canRequestFocus,
-      descendantsAreFocusable: descendantsAreFocusable,
-    ));
+extension UseFocusNodeHook on Hookable {
+  /// Creates and dispose of a [FocusNode].
+  ///
+  /// See also:
+  /// - [FocusNode]
+  FocusNode useFocusNode({
+    String debugLabel,
+    FocusOnKeyCallback onKey,
+    bool skipTraversal = false,
+    bool canRequestFocus = true,
+    bool descendantsAreFocusable = true,
+  }) =>
+      use(_FocusNodeHook(
+        debugLabel: debugLabel,
+        onKey: onKey,
+        skipTraversal: skipTraversal,
+        canRequestFocus: canRequestFocus,
+        descendantsAreFocusable: descendantsAreFocusable,
+      ));
+}
 
 class _FocusNodeHook extends Hook<FocusNode> {
   const _FocusNodeHook({

--- a/lib/src/listenable.dart
+++ b/lib/src/listenable.dart
@@ -1,13 +1,15 @@
 part of 'hooks.dart';
 
-/// Subscribes to a [ValueListenable] and return its value.
-///
-/// See also:
-///   * [ValueListenable], the created object
-///   * [useListenable]
-T useValueListenable<T>(ValueListenable<T> valueListenable) {
-  use(_UseValueListenableHook(valueListenable));
-  return valueListenable.value;
+extension UseValueListenableHook on Hookable {
+  /// Subscribes to a [ValueListenable] and return its value.
+  ///
+  /// See also:
+  ///   * [ValueListenable], the created object
+  ///   * [useListenable]
+  T useValueListenable<T>(ValueListenable<T> valueListenable) {
+    use(_UseValueListenableHook(valueListenable));
+    return valueListenable.value;
+  }
 }
 
 class _UseValueListenableHook extends _ListenableHook {
@@ -27,15 +29,17 @@ class _UseValueListenableStateHook extends _ListenableStateHook {
   Object get debugValue => (hook.listenable as ValueListenable).value;
 }
 
-/// Subscribes to a [Listenable] and mark the widget as needing build
-/// whenever the listener is called.
-///
-/// See also:
-///   * [Listenable]
-///   * [useValueListenable], [useAnimation]
-T useListenable<T extends Listenable>(T listenable) {
-  use(_ListenableHook(listenable));
-  return listenable;
+extension UseListenableHook on Hookable {
+  /// Subscribes to a [Listenable] and mark the widget as needing build
+  /// whenever the listener is called.
+  ///
+  /// See also:
+  ///   * [Listenable]
+  ///   * [useValueListenable], [useAnimation]
+  T useListenable<T extends Listenable>(T listenable) {
+    use(_ListenableHook(listenable));
+    return listenable;
+  }
 }
 
 class _ListenableHook extends Hook<void> {
@@ -83,19 +87,21 @@ class _ListenableStateHook extends HookState<void, _ListenableHook> {
   Object get debugValue => hook.listenable;
 }
 
-/// Creates a [ValueNotifier] automatically disposed.
-///
-/// As opposed to `useState`, this hook do not subscribes to [ValueNotifier].
-/// This allows a more granular rebuild.
-///
-/// See also:
-///   * [ValueNotifier]
-///   * [useValueListenable]
-ValueNotifier<T> useValueNotifier<T>([T intialData, List<Object> keys]) {
-  return use(_ValueNotifierHook(
-    initialData: intialData,
-    keys: keys,
-  ));
+extension UseValueNotifierHook on Hookable {
+  /// Creates a [ValueNotifier] automatically disposed.
+  ///
+  /// As opposed to `useState`, this hook do not subscribes to [ValueNotifier].
+  /// This allows a more granular rebuild.
+  ///
+  /// See also:
+  ///   * [ValueNotifier]
+  ///   * [useValueListenable]
+  ValueNotifier<T> useValueNotifier<T>([T intialData, List<Object> keys]) {
+    return use(_ValueNotifierHook(
+      initialData: intialData,
+      keys: keys,
+    ));
+  }
 }
 
 class _ValueNotifierHook<T> extends Hook<ValueNotifier<T>> {

--- a/lib/src/misc.dart
+++ b/lib/src/misc.dart
@@ -19,36 +19,38 @@ abstract class Store<State, Action> {
 /// [Reducer] must never return `null`, even if [state] or [action] are `null`.
 typedef Reducer<State, Action> = State Function(State state, Action action);
 
-/// An alternative to [useState] for more complex states.
-///
-/// [useReducer] manages an read only state that can be updated
-/// by dispatching actions which are interpreted by a [Reducer].
-///
-/// [reducer] is immediatly called on first build with [initialAction]
-/// and [initialState] as parameter.
-///
-/// It is possible to change the [reducer] by calling [useReducer]
-///  with a new [Reducer].
-///
-/// See also:
-///  * [Reducer]
-///  * [Store]
-Store<State, Action> useReducer<State extends Object, Action>(
-  Reducer<State, Action> reducer, {
-  State initialState,
-  Action initialAction,
-}) {
-  return use(
-    _ReducerdHook(
-      reducer,
-      initialAction: initialAction,
-      initialState: initialState,
-    ),
-  );
+extension UseReducerHook on Hookable {
+  /// An alternative to [useState] for more complex states.
+  ///
+  /// [useReducer] manages an read only state that can be updated
+  /// by dispatching actions which are interpreted by a [Reducer].
+  ///
+  /// [reducer] is immediatly called on first build with [initialAction]
+  /// and [initialState] as parameter.
+  ///
+  /// It is possible to change the [reducer] by calling [useReducer]
+  ///  with a new [Reducer].
+  ///
+  /// See also:
+  ///  * [Reducer]
+  ///  * [Store]
+  Store<State, Action> useReducer<State extends Object, Action>(
+    Reducer<State, Action> reducer, {
+    State initialState,
+    Action initialAction,
+  }) {
+    return use(
+      _ReducerHook(
+        reducer,
+        initialAction: initialAction,
+        initialState: initialState,
+      ),
+    );
+  }
 }
 
-class _ReducerdHook<State, Action> extends Hook<Store<State, Action>> {
-  const _ReducerdHook(this.reducer, {this.initialState, this.initialAction})
+class _ReducerHook<State, Action> extends Hook<Store<State, Action>> {
+  const _ReducerHook(this.reducer, {this.initialState, this.initialAction})
       : assert(reducer != null, 'reducer cannot be null');
 
   final Reducer<State, Action> reducer;
@@ -56,12 +58,12 @@ class _ReducerdHook<State, Action> extends Hook<Store<State, Action>> {
   final Action initialAction;
 
   @override
-  _ReducerdHookState<State, Action> createState() =>
-      _ReducerdHookState<State, Action>();
+  _ReducerHookState<State, Action> createState() =>
+      _ReducerHookState<State, Action>();
 }
 
-class _ReducerdHookState<State, Action>
-    extends HookState<Store<State, Action>, _ReducerdHook<State, Action>>
+class _ReducerHookState<State, Action>
+    extends HookState<Store<State, Action>, _ReducerHook<State, Action>>
     implements Store<State, Action> {
   @override
   State state;
@@ -95,9 +97,11 @@ class _ReducerdHookState<State, Action>
   Object get debugValue => state;
 }
 
-/// Returns the previous argument called to [usePrevious].
-T usePrevious<T>(T val) {
-  return use(_PreviousHook(val));
+extension UsePreviousHook on Hookable {
+  /// Returns the previous argument called to [usePrevious].
+  T usePrevious<T>(T val) {
+    return use(_PreviousHook(val));
+  }
 }
 
 class _PreviousHook<T> extends Hook<T> {
@@ -127,17 +131,19 @@ class _PreviousHookState<T> extends HookState<T, _PreviousHook<T>> {
   Object get debugValue => previous;
 }
 
-/// Runs the callback on every hot reload
-/// similar to reassemble in the Stateful widgets
-///
-/// See also:
-///
-///  * [State.reassemble]
-void useReassemble(VoidCallback callback) {
-  assert(() {
-    use(_ReassembleHook(callback));
-    return true;
-  }(), '');
+extension UseReassembleHook on Hookable {
+  /// Runs the callback on every hot reload
+  /// similar to reassemble in the Stateful widgets
+  ///
+  /// See also:
+  ///
+  ///  * [State.reassemble]
+  void useReassemble(VoidCallback callback) {
+    assert(() {
+      use(_ReassembleHook(callback));
+      return true;
+    }(), '');
+  }
 }
 
 class _ReassembleHook extends Hook<void> {
@@ -167,25 +173,27 @@ class _ReassembleHookState extends HookState<void, _ReassembleHook> {
   bool get debugSkipValue => true;
 }
 
-/// Returns an [IsMounted] object that you can use
-/// to check if the [State] is mounted.
-///
-/// ```dart
-/// final isMounted = useIsMounted();
-/// useEffect((){
-///   myFuture.then((){
-///     if (isMounted()) {
-///       // Do something
-///     }
-///   });
-///   return null;
-/// }, []);
-/// ```
-///
-/// See also:
-///   * The [State.mounted] property.
-IsMounted useIsMounted() {
-  return use(const _IsMountedHook());
+extension UseIsMountedHook on Hookable {
+  /// Returns an [IsMounted] object that you can use
+  /// to check if the [State] is mounted.
+  ///
+  /// ```dart
+  /// final isMounted = useIsMounted();
+  /// useEffect((){
+  ///   myFuture.then((){
+  ///     if (isMounted()) {
+  ///       // Do something
+  ///     }
+  ///   });
+  ///   return null;
+  /// }, []);
+  /// ```
+  ///
+  /// See also:
+  ///   * The [State.mounted] property.
+  IsMounted useIsMounted() {
+    return use(const _IsMountedHook());
+  }
 }
 
 class _IsMountedHook extends Hook<IsMounted> {

--- a/lib/src/page_controller.dart
+++ b/lib/src/page_controller.dart
@@ -1,23 +1,25 @@
 part of 'hooks.dart';
 
-/// Creates and disposes a [PageController].
-///
-/// See also:
-/// - [PageController]
-PageController usePageController({
-  int initialPage = 0,
-  bool keepPage = true,
-  double viewportFraction = 1.0,
-  List<Object> keys,
-}) {
-  return use(
-    _PageControllerHook(
-      initialPage: initialPage,
-      keepPage: keepPage,
-      viewportFraction: viewportFraction,
-      keys: keys,
-    ),
-  );
+extension UsePageControllerHook on Hookable {
+  /// Creates and disposes a [PageController].
+  ///
+  /// See also:
+  /// - [PageController]
+  PageController usePageController({
+    int initialPage = 0,
+    bool keepPage = true,
+    double viewportFraction = 1.0,
+    List<Object> keys,
+  }) {
+    return use(
+      _PageControllerHook(
+        initialPage: initialPage,
+        keepPage: keepPage,
+        viewportFraction: viewportFraction,
+        keys: keys,
+      ),
+    );
+  }
 }
 
 class _PageControllerHook extends Hook<PageController> {

--- a/lib/src/primitives.dart
+++ b/lib/src/primitives.dart
@@ -1,17 +1,19 @@
 part of 'hooks.dart';
 
-/// Cache the instance of a complex object.
-///
-/// [useMemoized] will immediatly call [valueBuilder] on first call and store its result.
-/// Later, when [HookWidget] rebuilds, the call to [useMemoized] will return the previously created instance without calling [valueBuilder].
-///
-/// A later call of [useMemoized] with different [keys] will call [useMemoized] again to create a new instance.
-T useMemoized<T>(T Function() valueBuilder,
-    [List<Object> keys = const <dynamic>[]]) {
-  return use(_MemoizedHook(
-    valueBuilder,
-    keys: keys,
-  ));
+extension UseMemoizedHook on Hookable {
+  /// Cache the instance of a complex object.
+  ///
+  /// [useMemoized] will immediatly call [valueBuilder] on first call and store its result.
+  /// Later, when [HookWidget] rebuilds, the call to [useMemoized] will return the previously created instance without calling [valueBuilder].
+  ///
+  /// A later call of [useMemoized] with different [keys] will call [useMemoized] again to create a new instance.
+  T useMemoized<T>(T Function() valueBuilder,
+      [List<Object> keys = const <dynamic>[]]) {
+    return use(_MemoizedHook(
+      valueBuilder,
+      keys: keys,
+    ));
+  }
 }
 
 class _MemoizedHook<T> extends Hook<T> {
@@ -46,30 +48,32 @@ class _MemoizedHookState<T> extends HookState<T, _MemoizedHook<T>> {
   String get debugLabel => 'useMemoized<$T>';
 }
 
-/// Watches a value and calls a callback whenever the value changed.
-///
-/// [useValueChanged] takes a [valueChange] callback and calls it whenever [value] changed.
-/// [valueChange] will _not_ be called on the first [useValueChanged] call.
-///
-/// [useValueChanged] can also be used to interpolate
-/// Whenever [useValueChanged] is called with a diffent [value], calls [valueChange].
-/// The value returned by [useValueChanged] is the latest returned value of [valueChange] or `null`.
-///
-/// The following example calls [AnimationController.forward] whenever `color` changes
-///
-/// ```dart
-/// AnimationController controller;
-/// Color color;
-///
-/// useValueChanged(color, (_, __)) {
-///     controller.forward();
-/// });
-/// ```
-R useValueChanged<T, R>(
-  T value,
-  R Function(T oldValue, R oldResult) valueChange,
-) {
-  return use(_ValueChangedHook(value, valueChange));
+extension UseValueChangedHook on Hookable {
+  /// Watches a value and calls a callback whenever the value changed.
+  ///
+  /// [useValueChanged] takes a [valueChange] callback and calls it whenever [value] changed.
+  /// [valueChange] will _not_ be called on the first [useValueChanged] call.
+  ///
+  /// [useValueChanged] can also be used to interpolate
+  /// Whenever [useValueChanged] is called with a diffent [value], calls [valueChange].
+  /// The value returned by [useValueChanged] is the latest returned value of [valueChange] or `null`.
+  ///
+  /// The following example calls [AnimationController.forward] whenever `color` changes
+  ///
+  /// ```dart
+  /// AnimationController controller;
+  /// Color color;
+  ///
+  /// useValueChanged(color, (_, __)) {
+  ///     controller.forward();
+  /// });
+  /// ```
+  R useValueChanged<T, R>(
+    T value,
+    R Function(T oldValue, R oldResult) valueChange,
+  ) {
+    return use(_ValueChangedHook(value, valueChange));
+  }
 }
 
 class _ValueChangedHook<T, R> extends Hook<R> {
@@ -116,35 +120,37 @@ class _ValueChangedHookState<T, R>
 
 typedef Dispose = void Function();
 
-/// Useful for side-effects and optionally canceling them.
-///
-/// [useEffect] is called synchronously on every `build`, unless
-/// [keys] is specified. In which case [useEffect] is called again only if
-/// any value inside [keys] as changed.
-///
-/// It takes an [effect] callback and calls it synchronously.
-/// That [effect] may optionally return a function, which will be called when the [effect] is called again or if the widget is disposed.
-///
-/// By default [effect] is called on every `build` call, unless [keys] is specified.
-/// In which case, [effect] is called once on the first [useEffect] call and whenever something within [keys] change/
-///
-/// The following example call [useEffect] to subscribes to a [Stream] and cancel the subscription when the widget is disposed.
-/// ALso ifthe [Stream] change, it will cancel the listening on the previous [Stream] and listen to the new one.
-///
-/// ```dart
-/// Stream stream;
-/// useEffect(() {
-///     final subscription = stream.listen(print);
-///     // This will cancel the subscription when the widget is disposed
-///     // or if the callback is called again.
-///     return subscription.cancel;
-///   },
-///   // when the stream change, useEffect will call the callback again.
-///   [stream],
-/// );
-/// ```
-void useEffect(Dispose Function() effect, [List<Object> keys]) {
-  use(_EffectHook(effect, keys));
+extension UseEffectHook on Hookable {
+  /// Useful for side-effects and optionally canceling them.
+  ///
+  /// [useEffect] is called synchronously on every `build`, unless
+  /// [keys] is specified. In which case [useEffect] is called again only if
+  /// any value inside [keys] as changed.
+  ///
+  /// It takes an [effect] callback and calls it synchronously.
+  /// That [effect] may optionally return a function, which will be called when the [effect] is called again or if the widget is disposed.
+  ///
+  /// By default [effect] is called on every `build` call, unless [keys] is specified.
+  /// In which case, [effect] is called once on the first [useEffect] call and whenever something within [keys] change/
+  ///
+  /// The following example call [useEffect] to subscribes to a [Stream] and cancel the subscription when the widget is disposed.
+  /// ALso ifthe [Stream] change, it will cancel the listening on the previous [Stream] and listen to the new one.
+  ///
+  /// ```dart
+  /// Stream stream;
+  /// useEffect(() {
+  ///     final subscription = stream.listen(print);
+  ///     // This will cancel the subscription when the widget is disposed
+  ///     // or if the callback is called again.
+  ///     return subscription.cancel;
+  ///   },
+  ///   // when the stream change, useEffect will call the callback again.
+  ///   [stream],
+  /// );
+  /// ```
+  void useEffect(Dispose Function() effect, [List<Object> keys]) {
+    use(_EffectHook(effect, keys));
+  }
 }
 
 class _EffectHook extends Hook<void> {
@@ -200,36 +206,38 @@ class _EffectHookState extends HookState<void, _EffectHook> {
   bool get debugSkipValue => true;
 }
 
-/// Create variable and subscribes to it.
-///
-/// Whenever [ValueNotifier.value] updates, it will mark the caller [HookWidget]
-/// as needing build.
-/// On first call, inits [ValueNotifier] to [initialData]. [initialData] is ignored
-/// on subsequent calls.
-///
-/// The following example showcase a basic counter application.
-///
-/// ```dart
-/// class Counter extends HookWidget {
-///   @override
-///   Widget build(BuildContext context) {
-///     final counter = useState(0);
-///
-///     return GestureDetector(
-///       // automatically triggers a rebuild of Counter widget
-///       onTap: () => counter.value++,
-///       child: Text(counter.value.toString()),
-///     );
-///   }
-/// }
-/// ```
-///
-/// See also:
-///
-///  * [ValueNotifier]
-///  * [useStreamController], an alternative to [ValueNotifier] for state.
-ValueNotifier<T> useState<T>([T initialData]) {
-  return use(_StateHook(initialData: initialData));
+extension UseStateHook on Hookable {
+  /// Create variable and subscribes to it.
+  ///
+  /// Whenever [ValueNotifier.value] updates, it will mark the caller [HookWidget]
+  /// as needing build.
+  /// On first call, inits [ValueNotifier] to [initialData]. [initialData] is ignored
+  /// on subsequent calls.
+  ///
+  /// The following example showcase a basic counter application.
+  ///
+  /// ```dart
+  /// class Counter extends HookWidget {
+  ///   @override
+  ///   Widget build(BuildContext context) {
+  ///     final counter = useState(0);
+  ///
+  ///     return GestureDetector(
+  ///       // automatically triggers a rebuild of Counter widget
+  ///       onTap: () => counter.value++,
+  ///       child: Text(counter.value.toString()),
+  ///     );
+  ///   }
+  /// }
+  /// ```
+  ///
+  /// See also:
+  ///
+  ///  * [ValueNotifier]
+  ///  * [useStreamController], an alternative to [ValueNotifier] for state.
+  ValueNotifier<T> useState<T>([T initialData]) {
+    return use(_StateHook(initialData: initialData));
+  }
 }
 
 class _StateHook<T> extends Hook<ValueNotifier<T>> {

--- a/lib/src/scroll_controller.dart
+++ b/lib/src/scroll_controller.dart
@@ -1,23 +1,25 @@
 part of 'hooks.dart';
 
-/// Creates and disposes a [ScrollController].
-///
-/// See also:
-/// - [ScrollController]
-ScrollController useScrollController({
-  double initialScrollOffset = 0.0,
-  bool keepScrollOffset = true,
-  String debugLabel,
-  List<Object> keys,
-}) {
-  return use(
-    _ScrollControllerHook(
-      initialScrollOffset: initialScrollOffset,
-      keepScrollOffset: keepScrollOffset,
-      debugLabel: debugLabel,
-      keys: keys,
-    ),
-  );
+extension UseScrollControllerHook on Hookable {
+  /// Creates and disposes a [ScrollController].
+  ///
+  /// See also:
+  /// - [ScrollController]
+  ScrollController useScrollController({
+    double initialScrollOffset = 0.0,
+    bool keepScrollOffset = true,
+    String debugLabel,
+    List<Object> keys,
+  }) {
+    return use(
+      _ScrollControllerHook(
+        initialScrollOffset: initialScrollOffset,
+        keepScrollOffset: keepScrollOffset,
+        debugLabel: debugLabel,
+        keys: keys,
+      ),
+    );
+  }
 }
 
 class _ScrollControllerHook extends Hook<ScrollController> {

--- a/lib/src/tab_controller.dart
+++ b/lib/src/tab_controller.dart
@@ -1,23 +1,25 @@
 part of 'hooks.dart';
 
-/// Creates and disposes a [TabController].
-///
-/// See also:
-/// - [TabController]
-TabController useTabController({
-  @required int initialLength,
-  TickerProvider vsync,
-  int initialIndex = 0,
-  List<Object> keys,
-}) {
-  vsync ??= useSingleTickerProvider(keys: keys);
+extension UseTabControllerHook on Hookable {
+  /// Creates and disposes a [TabController].
+  ///
+  /// See also:
+  /// - [TabController]
+  TabController useTabController({
+    @required int initialLength,
+    TickerProvider vsync,
+    int initialIndex = 0,
+    List<Object> keys,
+  }) {
+    vsync ??= useSingleTickerProvider(keys: keys);
 
-  return use(_TabControllerHook(
-    vsync: vsync,
-    length: initialLength,
-    initialIndex: initialIndex,
-    keys: keys,
-  ));
+    return use(_TabControllerHook(
+      vsync: vsync,
+      length: initialLength,
+      initialIndex: initialIndex,
+      keys: keys,
+    ));
+  }
 }
 
 class _TabControllerHook extends Hook<TabController> {

--- a/lib/src/text_controller.dart
+++ b/lib/src/text_controller.dart
@@ -1,6 +1,6 @@
 part of 'hooks.dart';
 
-class _TextEditingControllerHookCreator {
+class _TextEditingControllerHookCreator implements Hookable {
   const _TextEditingControllerHookCreator();
 
   /// Creates a [TextEditingController] that will be disposed automatically.
@@ -36,7 +36,7 @@ class _TextEditingControllerHookCreator {
 /// effect whatsoever. To update the value in a callback, for instance after a
 /// button was pressed, use the [TextEditingController.text] or
 /// [TextEditingController.text] setters. To have the [TextEditingController]
-/// reflect changing values, you can use [useEffect]. This example will update
+/// reflect changing values, you can use `useEffect`. This example will update
 /// the [TextEditingController.text] whenever a provided [ValueListenable]
 /// changes:
 /// ```dart

--- a/test/hook_builder_test.dart
+++ b/test/hook_builder_test.dart
@@ -5,8 +5,8 @@ import 'package:flutter_test/flutter_test.dart';
 void main() {
   testWidgets('simple build', (tester) async {
     await tester.pumpWidget(
-      HookBuilder(builder: (context) {
-        final state = useState(42).value;
+      HookBuilder(builder: (context, h) {
+        final state = h.useState(42).value;
         return Text('$state', textDirection: TextDirection.ltr);
       }),
     );

--- a/test/hook_widget_test.dart
+++ b/test/hook_widget_test.dart
@@ -60,9 +60,9 @@ void main() {
     final second = MockDispose();
 
     await tester.pumpWidget(
-      HookBuilder(builder: (c) {
-        useEffect(() => first, [0]);
-        useEffect(() => second, [0]);
+      HookBuilder(builder: (c, h) {
+        h.useEffect(() => first, [0]);
+        h.useEffect(() => second, [0]);
         return Container();
       }),
     );
@@ -71,9 +71,9 @@ void main() {
     verifyZeroInteractions(second);
 
     await tester.pumpWidget(
-      HookBuilder(builder: (c) {
-        useEffect(() => first, [1]);
-        useEffect(() => second, [1]);
+      HookBuilder(builder: (c, h) {
+        h.useEffect(() => first, [1]);
+        h.useEffect(() => second, [1]);
         return Container();
       }),
     );
@@ -99,9 +99,9 @@ void main() {
     final second = MockDispose();
 
     await tester.pumpWidget(
-      HookBuilder(builder: (c) {
-        useEffect(() => first);
-        useEffect(() => second);
+      HookBuilder(builder: (c, h) {
+        h.useEffect(() => first);
+        h.useEffect(() => second);
         return Container();
       }),
     );
@@ -156,16 +156,16 @@ void main() {
                 key: const Key('1'),
                 child: HookBuilder(
                   key: value ? _key2 : _key1,
-                  builder: (context) {
-                    use(HookTest<int>(deactivate: deactivate1));
+                  builder: (context, h) {
+                    h.use(HookTest<int>(deactivate: deactivate1));
                     return Container();
                   },
                 ),
               ),
               HookBuilder(
                 key: !value ? _key2 : _key1,
-                builder: (context) {
-                  use(HookTest<int>(deactivate: deactivate2));
+                builder: (context, h) {
+                  h.use(HookTest<int>(deactivate: deactivate2));
                   return Container();
                 },
               ),
@@ -212,9 +212,9 @@ void main() {
 
     final widget = HookBuilder(
       key: _key,
-      builder: (context) {
-        use(HookTest<int>(deactivate: deactivate));
-        use(HookTest<int>(deactivate: deactivate2));
+      builder: (context, h) {
+        h.use(HookTest<int>(deactivate: deactivate));
+        h.use(HookTest<int>(deactivate: deactivate2));
         return Container();
       },
     );
@@ -248,8 +248,8 @@ void main() {
   testWidgets('should not allow using inheritedwidgets inside initHook',
       (tester) async {
     await tester.pumpWidget(
-      HookBuilder(builder: (_) {
-        use(InheritedInitHook());
+      HookBuilder(builder: (_, h) {
+        h.use(InheritedInitHook());
         return Container();
       }),
     );
@@ -266,8 +266,8 @@ void main() {
     });
 
     await tester.pumpWidget(
-      HookBuilder(builder: (_) {
-        use(HookTest<void>(build: build));
+      HookBuilder(builder: (_, h) {
+        h.use(HookTest<void>(build: build));
         return Container();
       }),
     );
@@ -278,8 +278,8 @@ void main() {
     addTearDown(() => debugHotReloadHooksEnabled = true);
 
     await tester.pumpWidget(
-      HookBuilder(builder: (_) {
-        notifier = useState(0);
+      HookBuilder(builder: (_, h) {
+        notifier = h.useState(0);
 
         return Text(notifier.value.toString(),
             textDirection: TextDirection.ltr);
@@ -296,9 +296,9 @@ void main() {
 
   testWidgets('HookElement exposes an immutable list of hooks', (tester) async {
     await tester.pumpWidget(
-      HookBuilder(builder: (_) {
-        use(HookTest<int>());
-        use(HookTest<String>());
+      HookBuilder(builder: (_, h) {
+        h.use(HookTest<int>());
+        h.use(HookTest<String>());
         return Container();
       }),
     );
@@ -314,34 +314,34 @@ void main() {
       'until one build finishes without crashing, it is possible to add hooks',
       (tester) async {
     await tester.pumpWidget(
-      HookBuilder(builder: (_) {
+      HookBuilder(builder: (_, __) {
         throw 0;
       }),
     );
     expect(tester.takeException(), 0);
 
     await tester.pumpWidget(
-      HookBuilder(builder: (_) {
-        use(HookTest<int>());
+      HookBuilder(builder: (_, h) {
+        h.use(HookTest<int>());
         throw 1;
       }),
     );
     expect(tester.takeException(), 1);
 
     await tester.pumpWidget(
-      HookBuilder(builder: (_) {
-        use(HookTest<int>());
-        use(HookTest<String>());
+      HookBuilder(builder: (_, h) {
+        h.use(HookTest<int>());
+        h.use(HookTest<String>());
         throw 2;
       }),
     );
     expect(tester.takeException(), 2);
 
     await tester.pumpWidget(
-      HookBuilder(builder: (_) {
-        use(HookTest<int>());
-        use(HookTest<String>());
-        use(HookTest<double>());
+      HookBuilder(builder: (_, h) {
+        h.use(HookTest<int>());
+        h.use(HookTest<String>());
+        h.use(HookTest<double>());
         return Container();
       }),
     );
@@ -350,25 +350,25 @@ void main() {
       'until one build finishes without crashing, it is possible to add hooks #2',
       (tester) async {
     await tester.pumpWidget(
-      HookBuilder(builder: (_) {
+      HookBuilder(builder: (_, __) {
         throw 0;
       }),
     );
     expect(tester.takeException(), 0);
 
     await tester.pumpWidget(
-      HookBuilder(builder: (_) {
-        use(HookTest<int>());
+      HookBuilder(builder: (_, h) {
+        h.use(HookTest<int>());
         throw 1;
       }),
     );
     expect(tester.takeException(), 1);
 
     await tester.pumpWidget(
-      HookBuilder(builder: (_) {
-        use(HookTest<int>());
-        use(HookTest<String>());
-        use(HookTest<double>());
+      HookBuilder(builder: (_, h) {
+        h.use(HookTest<int>());
+        h.use(HookTest<String>());
+        h.use(HookTest<double>());
         throw 2;
       }),
     );
@@ -379,7 +379,7 @@ void main() {
       "After hot-reload that throws it's still possible to add hooks until one build suceed",
       (tester) async {
     await tester.pumpWidget(
-      HookBuilder(builder: (_) {
+      HookBuilder(builder: (_, __) {
         return Container();
       }),
     );
@@ -387,15 +387,15 @@ void main() {
     hotReload(tester);
 
     await tester.pumpWidget(
-      HookBuilder(builder: (_) {
+      HookBuilder(builder: (_, __) {
         throw 0;
       }),
     );
     expect(tester.takeException(), 0);
 
     await tester.pumpWidget(
-      HookBuilder(builder: (_) {
-        use(HookTest<int>());
+      HookBuilder(builder: (_, h) {
+        h.use(HookTest<int>());
         return Container();
       }),
     );
@@ -405,8 +405,8 @@ void main() {
       'After hot-reload that throws, hooks are correctly disposed when build suceeeds with less hooks',
       (tester) async {
     await tester.pumpWidget(
-      HookBuilder(builder: (_) {
-        use(createHook());
+      HookBuilder(builder: (_, h) {
+        h.use(createHook());
         return Container();
       }),
     );
@@ -414,7 +414,7 @@ void main() {
     hotReload(tester);
 
     await tester.pumpWidget(
-      HookBuilder(builder: (_) {
+      HookBuilder(builder: (_, __) {
         throw 0;
       }),
     );
@@ -425,7 +425,7 @@ void main() {
     verifyNoMoreInteractions(dispose);
 
     await tester.pumpWidget(
-      HookBuilder(builder: (_) {
+      HookBuilder(builder: (_, __) {
         return Container();
       }),
     );
@@ -437,9 +437,9 @@ void main() {
     final dispose2 = MockDispose();
 
     await tester.pumpWidget(
-      HookBuilder(builder: (context) {
-        use(HookTest<int>(dispose: dispose));
-        use(HookTest<String>(dispose: dispose2));
+      HookBuilder(builder: (context, h) {
+        h.use(HookTest<int>(dispose: dispose));
+        h.use(HookTest<String>(dispose: dispose2));
         return Container();
       }),
     );
@@ -448,9 +448,9 @@ void main() {
     verifyZeroInteractions(dispose2);
 
     await tester.pumpWidget(
-      HookBuilder(builder: (context) {
-        use(HookTest<int>(dispose: dispose, keys: const []));
-        use(HookTest<String>(dispose: dispose2));
+      HookBuilder(builder: (context, h) {
+        h.use(HookTest<int>(dispose: dispose, keys: const []));
+        h.use(HookTest<String>(dispose: dispose2));
         return Container();
       }),
     );
@@ -459,9 +459,9 @@ void main() {
     verifyZeroInteractions(dispose2);
 
     await tester.pumpWidget(
-      HookBuilder(builder: (context) {
-        use(HookTest<int>(dispose: dispose, keys: const []));
-        use(HookTest<String>(dispose: dispose2, keys: const []));
+      HookBuilder(builder: (context, h) {
+        h.use(HookTest<int>(dispose: dispose, keys: const []));
+        h.use(HookTest<String>(dispose: dispose2, keys: const []));
         return Container();
       }),
     );
@@ -476,8 +476,8 @@ void main() {
     when(createState()).thenReturn(HookStateTest<int>());
 
     Widget $build() {
-      return HookBuilder(builder: (context) {
-        use(
+      return HookBuilder(builder: (context, h) {
+        h.use(
           HookTest<int>(
             build: build,
             dispose: dispose,
@@ -565,9 +565,9 @@ void main() {
     MyHookState state;
 
     await tester.pumpWidget(HookBuilder(
-      builder: (context) {
+      builder: (context, h) {
         hookContext = context as HookElement;
-        state = use(hook);
+        state = h.use(hook);
         return Container();
       },
     ));
@@ -589,9 +589,9 @@ void main() {
     when(build(any)).thenReturn(42);
 
     await tester.pumpWidget(HookBuilder(
-      builder: (context) {
+      builder: (context, h) {
         hook = createHook();
-        result = use(hook);
+        result = h.use(hook);
         return Container();
       },
     ));
@@ -608,9 +608,9 @@ void main() {
     var previousHook = hook;
 
     await tester.pumpWidget(HookBuilder(
-      builder: (context) {
+      builder: (context, h) {
         hook = createHook();
-        result = use(hook);
+        result = h.use(hook);
         return Container();
       },
     ));
@@ -639,9 +639,9 @@ void main() {
     when(build(any)).thenReturn(42);
 
     await tester.pumpWidget(
-      HookBuilder(builder: (context) {
-        use(createHook());
-        use(HookTest<int>(dispose: dispose2));
+      HookBuilder(builder: (context, h) {
+        h.use(createHook());
+        h.use(HookTest<int>(dispose: dispose2));
         return Container();
       }),
     );
@@ -662,8 +662,8 @@ void main() {
     final hook = createHook();
 
     await tester.pumpWidget(
-      HookBuilder(builder: (context) {
-        use(hook);
+      HookBuilder(builder: (context, h) {
+        h.use(hook);
         return Container();
       }),
     );
@@ -676,8 +676,8 @@ void main() {
     verifyZeroInteractions(dispose);
 
     await tester.pumpWidget(
-      HookBuilder(builder: (context) {
-        use(hook);
+      HookBuilder(builder: (context, h) {
+        h.use(hook);
         return Container();
       }),
     );
@@ -692,15 +692,15 @@ void main() {
 
   testWidgets('rebuild with different hooks crash', (tester) async {
     await tester.pumpWidget(
-      HookBuilder(builder: (context) {
-        use(HookTest<int>());
+      HookBuilder(builder: (context, h) {
+        h.use(HookTest<int>());
         return Container();
       }),
     );
 
     await tester.pumpWidget(
-      HookBuilder(builder: (context) {
-        use(HookTest<String>());
+      HookBuilder(builder: (context, h) {
+        h.use(HookTest<String>());
         return Container();
       }),
     );
@@ -709,8 +709,8 @@ void main() {
   });
   testWidgets('rebuilds can add new hooks', (tester) async {
     await tester.pumpWidget(
-      HookBuilder(builder: (context) {
-        final a = useState(false).value;
+      HookBuilder(builder: (context, h) {
+        final a = h.useState(false).value;
         return Text('$a', textDirection: TextDirection.ltr);
       }),
     );
@@ -718,9 +718,9 @@ void main() {
     expect(find.text('false'), findsOneWidget);
 
     await tester.pumpWidget(
-      HookBuilder(builder: (context) {
-        final a = useState(true).value;
-        final b = useState(42).value;
+      HookBuilder(builder: (context, h) {
+        final a = h.useState(true).value;
+        final b = h.useState(42).value;
 
         return Text('$a $b', textDirection: TextDirection.ltr);
       }),
@@ -731,9 +731,9 @@ void main() {
 
   testWidgets('rebuild can remove hooks', (tester) async {
     await tester.pumpWidget(
-      HookBuilder(builder: (context) {
-        final a = useState(false).value;
-        final b = useState(42).value;
+      HookBuilder(builder: (context, h) {
+        final a = h.useState(false).value;
+        final b = h.useState(42).value;
 
         return Text('$a $b', textDirection: TextDirection.ltr);
       }),
@@ -742,8 +742,8 @@ void main() {
     expect(find.text('false 42'), findsOneWidget);
 
     await tester.pumpWidget(
-      HookBuilder(builder: (context) {
-        final a = useState(true).value;
+      HookBuilder(builder: (context, h) {
+        final a = h.useState(true).value;
         return Text('$a', textDirection: TextDirection.ltr);
       }),
     );
@@ -752,13 +752,15 @@ void main() {
   });
 
   testWidgets('use call outside build crash', (tester) async {
+    Hookable outsideHookable;
     await tester.pumpWidget(
-      HookBuilder(builder: (context) {
+      HookBuilder(builder: (context, h) {
+        outsideHookable = h;
         return Container();
       }),
     );
 
-    expect(() => use(HookTest<int>()), throwsAssertionError);
+    expect(() => outsideHookable.use(HookTest<int>()), throwsAssertionError);
   });
 
   testWidgets('hot-reload triggers a build', (tester) async {
@@ -768,9 +770,9 @@ void main() {
     when(build(any)).thenReturn(42);
 
     await tester.pumpWidget(
-      HookBuilder(builder: (context) {
+      HookBuilder(builder: (context, h) {
         previousHook = createHook();
-        result = use(previousHook);
+        result = h.use(previousHook);
         return Container();
       }),
     );
@@ -801,9 +803,9 @@ void main() {
     final reassemble2 = MockReassemble();
     final didUpdateHook2 = MockDidUpdateHook();
     await tester.pumpWidget(
-      HookBuilder(builder: (context) {
-        use(createHook());
-        use(
+      HookBuilder(builder: (context, h) {
+        h.use(createHook());
+        h.use(
           HookTest<void>(
             reassemble: reassemble2,
             didUpdateHook: didUpdateHook2,
@@ -829,8 +831,8 @@ void main() {
 
   testWidgets("hot-reload don't reassemble newly added hooks", (tester) async {
     await tester.pumpWidget(
-      HookBuilder(builder: (context) {
-        use(HookTest<int>());
+      HookBuilder(builder: (context, h) {
+        h.use(HookTest<int>());
         return Container();
       }),
     );
@@ -839,9 +841,9 @@ void main() {
 
     hotReload(tester);
     await tester.pumpWidget(
-      HookBuilder(builder: (context) {
-        use(HookTest<int>());
-        use(createHook());
+      HookBuilder(builder: (context, h) {
+        h.use(HookTest<int>());
+        h.use(createHook());
         return Container();
       }),
     );
@@ -860,8 +862,8 @@ void main() {
     final build2 = MockBuild<String>();
 
     await tester.pumpWidget(
-      HookBuilder(builder: (context) {
-        use(hook1 = createHook());
+      HookBuilder(builder: (context, h) {
+        h.use(hook1 = createHook());
         return Container();
       }),
     );
@@ -878,9 +880,9 @@ void main() {
     hotReload(tester);
 
     await tester.pumpWidget(
-      HookBuilder(builder: (context) {
-        use(createHook());
-        use(
+      HookBuilder(builder: (context, h) {
+        h.use(createHook());
+        h.use(
           HookTest<String>(
             initHook: initHook2,
             build: build2,
@@ -912,8 +914,8 @@ void main() {
     final build2 = MockBuild<String>();
 
     await tester.pumpWidget(
-      HookBuilder(builder: (context) {
-        use(createHook());
+      HookBuilder(builder: (context, h) {
+        h.use(createHook());
         return Container();
       }),
     );
@@ -930,14 +932,14 @@ void main() {
     hotReload(tester);
 
     await tester.pumpWidget(
-      HookBuilder(builder: (context) {
-        use(HookTest<String>(
+      HookBuilder(builder: (context, h) {
+        h.use(HookTest<String>(
           initHook: initHook2,
           build: build2,
           didUpdateHook: didUpdateHook2,
           dispose: dispose2,
         ));
-        use(createHook());
+        h.use(createHook());
         return Container();
       }),
     );
@@ -961,9 +963,9 @@ void main() {
     final build2 = MockBuild<int>();
 
     await tester.pumpWidget(
-      HookBuilder(builder: (context) {
-        use(createHook());
-        use(
+      HookBuilder(builder: (context, h) {
+        h.use(createHook());
+        h.use(
           HookTest<int>(
             initHook: initHook2,
             build: build2,
@@ -991,7 +993,7 @@ void main() {
     hotReload(tester);
 
     await tester.pumpWidget(
-      HookBuilder(builder: (context) {
+      HookBuilder(builder: (context, h) {
         return Container();
       }),
     );
@@ -1028,11 +1030,11 @@ void main() {
     final build4 = MockBuild<int>();
 
     await tester.pumpWidget(
-      HookBuilder(builder: (context) {
-        use(hook1 = createHook());
-        use(HookTest<String>(dispose: dispose2));
-        use(HookTest<Object>(dispose: dispose3));
-        use(HookTest<void>(dispose: dispose4));
+      HookBuilder(builder: (context, h) {
+        h.use(hook1 = createHook());
+        h.use(HookTest<String>(dispose: dispose2));
+        h.use(HookTest<Object>(dispose: dispose3));
+        h.use(HookTest<void>(dispose: dispose4));
         return Container();
       }),
     );
@@ -1063,24 +1065,24 @@ void main() {
     hotReload(tester);
 
     await tester.pumpWidget(
-      HookBuilder(builder: (context) {
-        use(createHook());
+      HookBuilder(builder: (context, h) {
+        h.use(createHook());
         // changed type from HookTest<String>
-        use(
+        h.use(
           HookTest<int>(
             initHook: initHook2,
             build: build2,
             didUpdateHook: didUpdateHook2,
           ),
         );
-        use(
+        h.use(
           HookTest<int>(
             initHook: initHook3,
             build: build3,
             didUpdateHook: didUpdateHook3,
           ),
         );
-        use(
+        h.use(
           HookTest<int>(
             initHook: initHook4,
             build: build4,
@@ -1130,11 +1132,11 @@ void main() {
     final build4 = MockBuild<int>();
 
     await tester.pumpWidget(
-      HookBuilder(builder: (context) {
-        use(hook1 = createHook());
-        use(HookTest<String>(dispose: dispose2));
-        use(HookTest<Object>(dispose: dispose3));
-        use(HookTest<void>(dispose: dispose4));
+      HookBuilder(builder: (context, h) {
+        h.use(hook1 = createHook());
+        h.use(HookTest<String>(dispose: dispose2));
+        h.use(HookTest<Object>(dispose: dispose3));
+        h.use(HookTest<void>(dispose: dispose4));
         return Container();
       }),
     );
@@ -1164,20 +1166,20 @@ void main() {
 
     hotReload(tester);
     await tester.pumpWidget(
-      HookBuilder(builder: (context) {
-        use(createHook());
+      HookBuilder(builder: (context, h) {
+        h.use(createHook());
         // changed type from HookTest<String>
-        use(HookTest<int>(
+        h.use(HookTest<int>(
           initHook: initHook2,
           build: build2,
           didUpdateHook: didUpdateHook2,
         ));
-        use(HookTest<int>(
+        h.use(HookTest<int>(
           initHook: initHook3,
           build: build3,
           didUpdateHook: didUpdateHook3,
         ));
-        use(HookTest<int>(
+        h.use(HookTest<int>(
           initHook: initHook4,
           build: build4,
           didUpdateHook: didUpdateHook4,
@@ -1208,7 +1210,7 @@ void main() {
 
   testWidgets('hot-reload without hooks do not crash', (tester) async {
     await tester.pumpWidget(
-      HookBuilder(builder: (c) {
+      HookBuilder(builder: (c, _) {
         return Container();
       }),
     );
@@ -1219,8 +1221,8 @@ void main() {
 
   testWidgets('refreshes identical widgets on hot-reload', (tester) async {
     var value = 0;
-    final child = HookBuilder(builder: (context) {
-      use(MayHaveChangedOnReassemble());
+    final child = HookBuilder(builder: (context, h) {
+      h.use(MayHaveChangedOnReassemble());
 
       return Text('$value', textDirection: TextDirection.ltr);
     });
@@ -1283,7 +1285,7 @@ class MyStatefulHook extends StatefulHookWidget {
   _MyStatefulHookState createState() => _MyStatefulHookState();
 }
 
-class _MyStatefulHookState extends State<MyStatefulHook> {
+class _MyStatefulHookState extends State<MyStatefulHook> implements Hookable {
   int value;
 
   @override

--- a/test/is_mounted_test.dart
+++ b/test/is_mounted_test.dart
@@ -8,8 +8,8 @@ void main() {
     IsMounted isMounted;
 
     await tester.pumpWidget(HookBuilder(
-      builder: (context) {
-        isMounted = useIsMounted();
+      builder: (context, h) {
+        isMounted = h.useIsMounted();
         return Container();
       },
     ));
@@ -23,8 +23,8 @@ void main() {
 
   testWidgets('debugFillProperties', (tester) async {
     await tester.pumpWidget(
-      HookBuilder(builder: (context) {
-        useIsMounted();
+      HookBuilder(builder: (context, h) {
+        h.useIsMounted();
         return const SizedBox();
       }),
     );

--- a/test/memoized_test.dart
+++ b/test/memoized_test.dart
@@ -13,8 +13,8 @@ void main() {
 
   testWidgets('invalid parameters', (tester) async {
     await tester.pumpWidget(
-      HookBuilder(builder: (context) {
-        useMemoized<void>(null);
+      HookBuilder(builder: (context, h) {
+        h.useMemoized<void>(null);
         return Container();
       }),
     );
@@ -22,8 +22,8 @@ void main() {
     expect(tester.takeException(), isAssertionError);
 
     await tester.pumpWidget(
-      HookBuilder(builder: (context) {
-        useMemoized(() {}, null);
+      HookBuilder(builder: (context, h) {
+        h.useMemoized(() {}, null);
         return Container();
       }),
     );
@@ -37,8 +37,8 @@ void main() {
     when(valueBuilder()).thenReturn(42);
 
     await tester.pumpWidget(
-      HookBuilder(builder: (context) {
-        result = useMemoized<int>(valueBuilder);
+      HookBuilder(builder: (context, h) {
+        result = h.useMemoized<int>(valueBuilder);
         return Container();
       }),
     );
@@ -48,8 +48,8 @@ void main() {
     expect(result, 42);
 
     await tester.pumpWidget(
-      HookBuilder(builder: (context) {
-        result = useMemoized<int>(valueBuilder);
+      HookBuilder(builder: (context, h) {
+        result = h.useMemoized<int>(valueBuilder);
         return Container();
       }),
     );
@@ -70,8 +70,8 @@ void main() {
     when(valueBuilder()).thenReturn(0);
 
     await tester.pumpWidget(
-      HookBuilder(builder: (context) {
-        result = useMemoized<int>(valueBuilder, []);
+      HookBuilder(builder: (context, h) {
+        result = h.useMemoized<int>(valueBuilder, []);
         return Container();
       }),
     );
@@ -83,8 +83,8 @@ void main() {
     /* No change */
 
     await tester.pumpWidget(
-      HookBuilder(builder: (context) {
-        result = useMemoized<int>(valueBuilder, []);
+      HookBuilder(builder: (context, h) {
+        result = h.useMemoized<int>(valueBuilder, []);
         return Container();
       }),
     );
@@ -97,8 +97,8 @@ void main() {
     when(valueBuilder()).thenReturn(1);
 
     await tester.pumpWidget(
-      HookBuilder(builder: (context) {
-        result = useMemoized<int>(valueBuilder, ['foo']);
+      HookBuilder(builder: (context, h) {
+        result = h.useMemoized<int>(valueBuilder, ['foo']);
         return Container();
       }),
     );
@@ -110,8 +110,8 @@ void main() {
     /* No change */
 
     await tester.pumpWidget(
-      HookBuilder(builder: (context) {
-        result = useMemoized<int>(valueBuilder, ['foo']);
+      HookBuilder(builder: (context, h) {
+        result = h.useMemoized<int>(valueBuilder, ['foo']);
         return Container();
       }),
     );
@@ -124,8 +124,8 @@ void main() {
     when(valueBuilder()).thenReturn(2);
 
     await tester.pumpWidget(
-      HookBuilder(builder: (context) {
-        result = useMemoized<int>(valueBuilder, []);
+      HookBuilder(builder: (context, h) {
+        result = h.useMemoized<int>(valueBuilder, []);
         return Container();
       }),
     );
@@ -137,8 +137,8 @@ void main() {
     /* No change */
 
     await tester.pumpWidget(
-      HookBuilder(builder: (context) {
-        result = useMemoized<int>(valueBuilder, []);
+      HookBuilder(builder: (context, h) {
+        result = h.useMemoized<int>(valueBuilder, []);
         return Container();
       }),
     );
@@ -159,8 +159,8 @@ void main() {
     when(valueBuilder()).thenReturn(0);
 
     await tester.pumpWidget(
-      HookBuilder(builder: (context) {
-        result = useMemoized<int>(valueBuilder, ['foo', 42, 24.0]);
+      HookBuilder(builder: (context, h) {
+        result = h.useMemoized<int>(valueBuilder, ['foo', 42, 24.0]);
         return Container();
       }),
     );
@@ -172,8 +172,8 @@ void main() {
     /* Array reference changed but content didn't */
 
     await tester.pumpWidget(
-      HookBuilder(builder: (context) {
-        result = useMemoized<int>(valueBuilder, ['foo', 42, 24.0]);
+      HookBuilder(builder: (context, h) {
+        result = h.useMemoized<int>(valueBuilder, ['foo', 42, 24.0]);
         return Container();
       }),
     );
@@ -186,8 +186,8 @@ void main() {
     when(valueBuilder()).thenReturn(1);
 
     await tester.pumpWidget(
-      HookBuilder(builder: (context) {
-        result = useMemoized<int>(valueBuilder, [42, 'foo', 24.0]);
+      HookBuilder(builder: (context, h) {
+        result = h.useMemoized<int>(valueBuilder, [42, 'foo', 24.0]);
         return Container();
       }),
     );
@@ -199,8 +199,8 @@ void main() {
     when(valueBuilder()).thenReturn(2);
 
     await tester.pumpWidget(
-      HookBuilder(builder: (context) {
-        result = useMemoized<int>(valueBuilder, [42, 24.0, 'foo']);
+      HookBuilder(builder: (context, h) {
+        result = h.useMemoized<int>(valueBuilder, [42, 24.0, 'foo']);
         return Container();
       }),
     );
@@ -214,8 +214,8 @@ void main() {
     when(valueBuilder()).thenReturn(3);
 
     await tester.pumpWidget(
-      HookBuilder(builder: (context) {
-        result = useMemoized<int>(valueBuilder, [43, 24.0, 'foo']);
+      HookBuilder(builder: (context, h) {
+        result = h.useMemoized<int>(valueBuilder, [43, 24.0, 'foo']);
         return Container();
       }),
     );
@@ -228,8 +228,8 @@ void main() {
 
     // type change
     await tester.pumpWidget(
-      HookBuilder(builder: (context) {
-        result = useMemoized<int>(valueBuilder, [43, 24.0, 'foo']);
+      HookBuilder(builder: (context, h) {
+        result = h.useMemoized<int>(valueBuilder, [43, 24.0, 'foo']);
         return Container();
       }),
     );
@@ -253,8 +253,8 @@ void main() {
     when(valueBuilder()).thenReturn(0);
 
     await tester.pumpWidget(
-      HookBuilder(builder: (context) {
-        result = useMemoized<int>(valueBuilder, parameters);
+      HookBuilder(builder: (context, h) {
+        result = h.useMemoized<int>(valueBuilder, parameters);
         return Container();
       }),
     );
@@ -267,8 +267,8 @@ void main() {
     parameters.add(42);
 
     await tester.pumpWidget(
-      HookBuilder(builder: (context) {
-        result = useMemoized<int>(valueBuilder, parameters);
+      HookBuilder(builder: (context, h) {
+        result = h.useMemoized<int>(valueBuilder, parameters);
         return Container();
       }),
     );
@@ -284,9 +284,9 @@ void main() {
 
   testWidgets('debugFillProperties', (tester) async {
     await tester.pumpWidget(
-      HookBuilder(builder: (context) {
-        useMemoized<Future<int>>(() => Future.value(10));
-        useMemoized<int>(() => 43);
+      HookBuilder(builder: (context, h) {
+        h.useMemoized<Future<int>>(() => Future.value(10));
+        h.useMemoized<int>(() => 43);
         return const SizedBox();
       }),
     );

--- a/test/pre_build_abort_test.dart
+++ b/test/pre_build_abort_test.dart
@@ -12,10 +12,10 @@ void main() {
     final number = ValueNotifier(0);
 
     await tester.pumpWidget(
-      HookBuilder(builder: (c) {
-        final state = useState(false);
+      HookBuilder(builder: (c, h) {
+        final state = h.useState(false);
         state.value = true;
-        final isPositive = use(IsPositiveHook(number));
+        final isPositive = h.use(IsPositiveHook(number));
         return Text('$isPositive', textDirection: TextDirection.ltr);
       }),
     );
@@ -37,11 +37,11 @@ void main() {
     var buildCount = 0;
 
     await tester.pumpWidget(
-      HookBuilder(builder: (c) {
+      HookBuilder(builder: (c, h) {
         buildCount++;
-        final state = useState(false);
+        final state = h.useState(false);
         state.value = true;
-        final isPositive = use(IsPositiveHook(number));
+        final isPositive = h.use(IsPositiveHook(number));
         return Text('$isPositive', textDirection: TextDirection.ltr);
       }),
     );
@@ -63,9 +63,9 @@ void main() {
     var buildCount = 0;
 
     await tester.pumpWidget(
-      HookBuilder(builder: (c) {
+      HookBuilder(builder: (c, h) {
         buildCount++;
-        first = use(const MayRebuild());
+        first = h.use(const MayRebuild());
 
         return Container();
       }),
@@ -86,10 +86,10 @@ void main() {
     var buildCount = 0;
 
     await tester.pumpWidget(
-      HookBuilder(builder: (c) {
+      HookBuilder(builder: (c, h) {
         buildCount++;
-        first = use(MayRebuild(firstSpy));
-        second = use(MayRebuild(secondSpy));
+        first = h.use(MayRebuild(firstSpy));
+        second = h.use(MayRebuild(secondSpy));
 
         return Container();
       }),
@@ -131,9 +131,9 @@ void main() {
     final notifier = ValueNotifier(0);
 
     await tester.pumpWidget(
-      HookBuilder(builder: (c) {
+      HookBuilder(builder: (c, h) {
         buildCount++;
-        final value = use(IsPositiveHook(notifier));
+        final value = h.use(IsPositiveHook(notifier));
 
         return Text('$value', textDirection: TextDirection.ltr);
       }),
@@ -173,10 +173,10 @@ void main() {
     final notifier = ValueNotifier(0);
 
     await tester.pumpWidget(
-      HookBuilder(builder: (c) {
+      HookBuilder(builder: (c, h) {
         buildCount++;
-        useListenable(notifier);
-        final value = use(IsPositiveHook(notifier));
+        h.useListenable(notifier);
+        final value = h.use(IsPositiveHook(notifier));
 
         return Text('$value', textDirection: TextDirection.ltr);
       }),
@@ -199,9 +199,9 @@ void main() {
     final notifier = ValueNotifier(0);
 
     Widget build() {
-      return HookBuilder(builder: (c) {
+      return HookBuilder(builder: (c, h) {
         buildCount++;
-        final value = use(IsPositiveHook(notifier));
+        final value = h.use(IsPositiveHook(notifier));
 
         return Text('$value', textDirection: TextDirection.ltr);
       });
@@ -225,10 +225,10 @@ void main() {
     var buildCount = 0;
     final notifier = ValueNotifier(0);
 
-    final child = HookBuilder(builder: (c) {
+    final child = HookBuilder(builder: (c, h) {
       buildCount++;
       Directionality.of(c);
-      final value = use(IsPositiveHook(notifier));
+      final value = h.use(IsPositiveHook(notifier));
 
       return Text('$value', textDirection: TextDirection.ltr);
     });

--- a/test/use_animation_controller_test.dart
+++ b/test/use_animation_controller_test.dart
@@ -9,8 +9,8 @@ void main() {
     AnimationController controller;
 
     await tester.pumpWidget(
-      HookBuilder(builder: (context) {
-        controller = useAnimationController();
+      HookBuilder(builder: (context, h) {
+        controller = h.useAnimationController();
         return Container();
       }),
     );
@@ -33,8 +33,8 @@ void main() {
 
   testWidgets('diagnostics', (tester) async {
     await tester.pumpWidget(
-      HookBuilder(builder: (context) {
-        useAnimationController(
+      HookBuilder(builder: (context, h) {
+        h.useAnimationController(
           animationBehavior: AnimationBehavior.preserve,
           duration: const Duration(seconds: 1),
           initialValue: 42,
@@ -74,8 +74,8 @@ void main() {
     });
 
     await tester.pumpWidget(
-      HookBuilder(builder: (context) {
-        controller = useAnimationController(
+      HookBuilder(builder: (context, h) {
+        controller = h.useAnimationController(
           vsync: provider,
           animationBehavior: AnimationBehavior.preserve,
           duration: const Duration(seconds: 1),
@@ -109,8 +109,8 @@ void main() {
     });
 
     await tester.pumpWidget(
-      HookBuilder(builder: (context) {
-        controller = useAnimationController(
+      HookBuilder(builder: (context, h) {
+        controller = h.useAnimationController(
           vsync: provider,
           duration: const Duration(seconds: 2),
           debugLabel: 'Bar',
@@ -135,15 +135,15 @@ void main() {
 
   testWidgets('switch from uncontrolled to controlled throws', (tester) async {
     await tester.pumpWidget(HookBuilder(
-      builder: (context) {
-        useAnimationController();
+      builder: (context, h) {
+        h.useAnimationController();
         return Container();
       },
     ));
 
     await tester.pumpWidget(HookBuilder(
-      builder: (context) {
-        useAnimationController(vsync: tester);
+      builder: (context, h) {
+        h.useAnimationController(vsync: tester);
         return Container();
       },
     ));
@@ -152,15 +152,15 @@ void main() {
   });
   testWidgets('switch from controlled to uncontrolled throws', (tester) async {
     await tester.pumpWidget(HookBuilder(
-      builder: (context) {
-        useAnimationController(vsync: tester);
+      builder: (context, h) {
+        h.useAnimationController(vsync: tester);
         return Container();
       },
     ));
 
     await tester.pumpWidget(HookBuilder(
-      builder: (context) {
-        useAnimationController();
+      builder: (context, h) {
+        h.useAnimationController();
         return Container();
       },
     ));
@@ -172,8 +172,8 @@ void main() {
     List<Object> keys;
     AnimationController controller;
     await tester.pumpWidget(HookBuilder(
-      builder: (context) {
-        controller = useAnimationController(keys: keys);
+      builder: (context, h) {
+        controller = h.useAnimationController(keys: keys);
         return Container();
       },
     ));
@@ -182,8 +182,8 @@ void main() {
     keys = [];
 
     await tester.pumpWidget(HookBuilder(
-      builder: (context) {
-        controller = useAnimationController(keys: keys);
+      builder: (context, h) {
+        controller = h.useAnimationController(keys: keys);
         return Container();
       },
     ));

--- a/test/use_animation_test.dart
+++ b/test/use_animation_test.dart
@@ -7,8 +7,8 @@ import 'mock.dart';
 void main() {
   testWidgets('useAnimation throws with null', (tester) async {
     await tester.pumpWidget(HookBuilder(
-      builder: (context) {
-        useAnimation<void>(null);
+      builder: (context, h) {
+        h.useAnimation<void>(null);
         return Container();
       },
     ));
@@ -18,8 +18,8 @@ void main() {
 
   testWidgets('debugFillProperties', (tester) async {
     await tester.pumpWidget(
-      HookBuilder(builder: (context) {
-        useAnimation(const AlwaysStoppedAnimation(42));
+      HookBuilder(builder: (context, h) {
+        h.useAnimation(const AlwaysStoppedAnimation(42));
         return const SizedBox();
       }),
     );
@@ -44,8 +44,8 @@ void main() {
 
     Future<void> pump() {
       return tester.pumpWidget(HookBuilder(
-        builder: (context) {
-          result = useAnimation(listenable);
+        builder: (context, h) {
+          result = h.useAnimation(listenable);
           return Container();
         },
       ));

--- a/test/use_context_test.dart
+++ b/test/use_context_test.dart
@@ -9,8 +9,8 @@ void main() {
     testWidgets('returns current BuildContext during build', (tester) async {
       BuildContext res;
 
-      await tester.pumpWidget(HookBuilder(builder: (context) {
-        res = useContext();
+      await tester.pumpWidget(HookBuilder(builder: (context, h) {
+        res = h.useContext();
         return Container();
       }));
 
@@ -20,14 +20,15 @@ void main() {
     });
 
     testWidgets('crashed outside of build', (tester) async {
-      expect(useContext, throwsAssertionError);
+      const Hookable h = null;
+      expect(h.useContext, throwsAssertionError);
       await tester.pumpWidget(HookBuilder(
-        builder: (context) {
-          useContext();
+        builder: (context, h) {
+          h.useContext();
           return Container();
         },
       ));
-      expect(useContext, throwsAssertionError);
+      expect(h.useContext, throwsAssertionError);
     });
   });
 }

--- a/test/use_effect_test.dart
+++ b/test/use_effect_test.dart
@@ -10,8 +10,8 @@ void main() {
   List<Object> parameters;
 
   Widget builder() {
-    return HookBuilder(builder: (context) {
-      useEffect(effect, parameters);
+    return HookBuilder(builder: (context, h) {
+      h.useEffect(effect, parameters);
       unrelated();
       return Container();
     });
@@ -25,8 +25,8 @@ void main() {
 
   testWidgets('debugFillProperties', (tester) async {
     await tester.pumpWidget(
-      HookBuilder(builder: (context) {
-        useEffect(() {
+      HookBuilder(builder: (context, h) {
+        h.useEffect(() {
           return null;
         }, []);
         return const SizedBox();
@@ -49,8 +49,8 @@ void main() {
 
   testWidgets('useEffect null callback throws', (tester) async {
     await tester.pumpWidget(
-      HookBuilder(builder: (c) {
-        useEffect(null);
+      HookBuilder(builder: (c, h) {
+        h.useEffect(null);
         return Container();
       }),
     );
@@ -64,8 +64,8 @@ void main() {
     when(effect()).thenReturn(dispose);
 
     Widget builder() {
-      return HookBuilder(builder: (context) {
-        useEffect(effect);
+      return HookBuilder(builder: (context, h) {
+        h.useEffect(effect);
         unrelated();
         return Container();
       });
@@ -211,8 +211,8 @@ void main() {
     List<Object> parameters;
 
     Widget builder() {
-      return HookBuilder(builder: (context) {
-        useEffect(effect, parameters);
+      return HookBuilder(builder: (context, h) {
+        h.useEffect(effect, parameters);
         return Container();
       });
     }

--- a/test/use_focus_node_test.dart
+++ b/test/use_focus_node_test.dart
@@ -8,8 +8,8 @@ void main() {
   testWidgets('creates a focus node and disposes it', (tester) async {
     FocusNode focusNode;
     await tester.pumpWidget(
-      HookBuilder(builder: (_) {
-        focusNode = useFocusNode();
+      HookBuilder(builder: (_, h) {
+        focusNode = h.useFocusNode();
         return Container();
       }),
     );
@@ -21,8 +21,8 @@ void main() {
     final previousValue = focusNode;
 
     await tester.pumpWidget(
-      HookBuilder(builder: (_) {
-        focusNode = useFocusNode();
+      HookBuilder(builder: (_, h) {
+        focusNode = h.useFocusNode();
         return Container();
       }),
     );
@@ -42,8 +42,8 @@ void main() {
 
   testWidgets('debugFillProperties', (tester) async {
     await tester.pumpWidget(
-      HookBuilder(builder: (context) {
-        useFocusNode();
+      HookBuilder(builder: (context, h) {
+        h.useFocusNode();
         return const SizedBox();
       }),
     );
@@ -67,8 +67,8 @@ void main() {
 
     FocusNode focusNode;
     await tester.pumpWidget(
-      HookBuilder(builder: (_) {
-        focusNode = useFocusNode();
+      HookBuilder(builder: (_, h) {
+        focusNode = h.useFocusNode();
         return Container();
       }),
     );
@@ -85,8 +85,8 @@ void main() {
 
     FocusNode focusNode;
     await tester.pumpWidget(
-      HookBuilder(builder: (_) {
-        focusNode = useFocusNode(
+      HookBuilder(builder: (_, h) {
+        focusNode = h.useFocusNode(
           debugLabel: 'Foo',
           onKey: onKey,
           skipTraversal: true,
@@ -110,8 +110,8 @@ void main() {
 
     FocusNode focusNode;
     await tester.pumpWidget(
-      HookBuilder(builder: (_) {
-        focusNode = useFocusNode(
+      HookBuilder(builder: (_, h) {
+        focusNode = h.useFocusNode(
           debugLabel: 'Foo',
           onKey: onKey,
           skipTraversal: true,
@@ -123,8 +123,8 @@ void main() {
     );
 
     await tester.pumpWidget(
-      HookBuilder(builder: (_) {
-        focusNode = useFocusNode(
+      HookBuilder(builder: (_, h) {
+        focusNode = h.useFocusNode(
           debugLabel: 'Bar',
           onKey: onKey2,
         );

--- a/test/use_future_test.dart
+++ b/test/use_future_test.dart
@@ -10,9 +10,9 @@ void main() {
   testWidgets('default preserve state, changing future keeps previous value',
       (tester) async {
     AsyncSnapshot<int> value;
-    Widget Function(BuildContext) builder(Future<int> stream) {
-      return (context) {
-        value = useFuture(stream);
+    Widget Function(BuildContext, Hookable) builder(Future<int> stream) {
+      return (context, h) {
+        value = h.useFuture(stream);
         return Container();
       };
     }
@@ -34,8 +34,8 @@ void main() {
     final future = Future.value(42);
 
     await tester.pumpWidget(
-      HookBuilder(builder: (context) {
-        useFuture(future);
+      HookBuilder(builder: (context, h) {
+        h.useFuture(future);
         return const SizedBox();
       }),
     );
@@ -59,9 +59,9 @@ void main() {
   testWidgets('If preserveState == false, changing future resets value',
       (tester) async {
     AsyncSnapshot<int> value;
-    Widget Function(BuildContext) builder(Future<int> stream) {
-      return (context) {
-        value = useFuture(stream, preserveState: false);
+    Widget Function(BuildContext, Hookable) builder(Future<int> stream) {
+      return (context, h) {
+        value = h.useFuture(stream, preserveState: false);
         return Container();
       };
     }
@@ -79,10 +79,10 @@ void main() {
     expect(value.data, 42);
   });
 
-  Widget Function(BuildContext) snapshotText(Future<String> stream,
+  Widget Function(BuildContext, Hookable) snapshotText(Future<String> stream,
       {String initialData}) {
-    return (context) {
-      final snapshot = useFuture(stream, initialData: initialData);
+    return (context, h) {
+      final snapshot = h.useFuture(stream, initialData: initialData);
       return Text(snapshot.toString(), textDirection: TextDirection.ltr);
     };
   }

--- a/test/use_listenable_test.dart
+++ b/test/use_listenable_test.dart
@@ -8,8 +8,8 @@ void main() {
   testWidgets('useListenable throws with null', (tester) async {
     await tester.pumpWidget(
       HookBuilder(
-        builder: (context) {
-          useListenable(null);
+        builder: (context, h) {
+          h.useListenable(null);
           return Container();
         },
       ),
@@ -20,8 +20,8 @@ void main() {
 
   testWidgets('debugFillProperties', (tester) async {
     await tester.pumpWidget(
-      HookBuilder(builder: (context) {
-        useListenable(const AlwaysStoppedAnimation(42));
+      HookBuilder(builder: (context, h) {
+        h.useListenable(const AlwaysStoppedAnimation(42));
         return const SizedBox();
       }),
     );
@@ -45,8 +45,8 @@ void main() {
 
     Future<void> pump() {
       return tester.pumpWidget(HookBuilder(
-        builder: (context) {
-          useListenable(listenable);
+        builder: (context, h) {
+          h.useListenable(listenable);
           return Container();
         },
       ));

--- a/test/use_page_controller_test.dart
+++ b/test/use_page_controller_test.dart
@@ -9,8 +9,8 @@ import 'mock.dart';
 void main() {
   testWidgets('debugFillProperties', (tester) async {
     await tester.pumpWidget(
-      HookBuilder(builder: (context) {
-        usePageController();
+      HookBuilder(builder: (context, h) {
+        h.usePageController();
         return const SizedBox();
       }),
     );
@@ -35,9 +35,9 @@ void main() {
       PageController controller2;
 
       await tester.pumpWidget(
-        HookBuilder(builder: (context) {
+        HookBuilder(builder: (context, h) {
           controller2 = PageController();
-          controller = usePageController();
+          controller = h.usePageController();
           return Container();
         }),
       );
@@ -51,8 +51,8 @@ void main() {
       PageController controller2;
 
       await tester.pumpWidget(
-        HookBuilder(builder: (context) {
-          controller = usePageController();
+        HookBuilder(builder: (context, h) {
+          controller = h.usePageController();
           return Container();
         }),
       );
@@ -60,8 +60,8 @@ void main() {
       expect(controller, isA<PageController>());
 
       await tester.pumpWidget(
-        HookBuilder(builder: (context) {
-          controller2 = usePageController();
+        HookBuilder(builder: (context, h) {
+          controller2 = h.usePageController();
           return Container();
         }),
       );
@@ -74,8 +74,8 @@ void main() {
 
       await tester.pumpWidget(
         HookBuilder(
-          builder: (context) {
-            controller = usePageController(
+          builder: (context, h) {
+            controller = h.usePageController(
               initialPage: 42,
               keepPage: false,
               viewportFraction: 3.4,
@@ -96,8 +96,8 @@ void main() {
 
       await tester.pumpWidget(
         HookBuilder(
-          builder: (context) {
-            controller = usePageController();
+          builder: (context, h) {
+            controller = h.usePageController();
             return Container();
           },
         ),

--- a/test/use_previous_test.dart
+++ b/test/use_previous_test.dart
@@ -4,8 +4,8 @@ import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 Widget build(int value) => HookBuilder(
-      builder: (context) =>
-          Text(usePrevious(value).toString(), textDirection: TextDirection.ltr),
+      builder: (context, h) => Text(h.usePrevious(value).toString(),
+          textDirection: TextDirection.ltr),
     );
 void main() {
   group('usePrevious', () {
@@ -34,15 +34,15 @@ void main() {
 
   testWidgets('debugFillProperties', (tester) async {
     await tester.pumpWidget(
-      HookBuilder(builder: (context) {
-        usePrevious(42);
+      HookBuilder(builder: (context, h) {
+        h.usePrevious(42);
         return const SizedBox();
       }),
     );
 
     await tester.pumpWidget(
-      HookBuilder(builder: (context) {
-        usePrevious(21);
+      HookBuilder(builder: (context, h) {
+        h.usePrevious(21);
         return const SizedBox();
       }),
     );

--- a/test/use_reassemble_test.dart
+++ b/test/use_reassemble_test.dart
@@ -7,8 +7,8 @@ import 'mock.dart';
 void main() {
   testWidgets('useReassemble null callback throws', (tester) async {
     await tester.pumpWidget(
-      HookBuilder(builder: (c) {
-        useReassemble(null);
+      HookBuilder(builder: (c, h) {
+        h.useReassemble(null);
         return Container();
       }),
     );
@@ -19,8 +19,8 @@ void main() {
   testWidgets("hot-reload calls useReassemble's callback", (tester) async {
     final reassemble = MockReassemble();
 
-    await tester.pumpWidget(HookBuilder(builder: (context) {
-      useReassemble(reassemble);
+    await tester.pumpWidget(HookBuilder(builder: (context, h) {
+      h.useReassemble(reassemble);
       return Container();
     }));
 
@@ -35,8 +35,8 @@ void main() {
 
   testWidgets('debugFillProperties', (tester) async {
     await tester.pumpWidget(
-      HookBuilder(builder: (context) {
-        useReassemble(() {});
+      HookBuilder(builder: (context, h) {
+        h.useReassemble(() {});
         return const SizedBox();
       }),
     );

--- a/test/use_reducer_test.dart
+++ b/test/use_reducer_test.dart
@@ -7,8 +7,8 @@ import 'mock.dart';
 void main() {
   testWidgets('debugFillProperties', (tester) async {
     await tester.pumpWidget(
-      HookBuilder(builder: (context) {
-        useReducer<int, int>((state, action) => 42);
+      HookBuilder(builder: (context, h) {
+        h.useReducer<int, int>((state, action) => 42);
         return const SizedBox();
       }),
     );
@@ -34,8 +34,8 @@ void main() {
       Store<int, String> store;
       Future<void> pump() {
         return tester.pumpWidget(HookBuilder(
-          builder: (context) {
-            store = useReducer(reducer);
+          builder: (context, h) {
+            store = h.useReducer(reducer);
             return Container();
           },
         ));
@@ -76,8 +76,8 @@ void main() {
     testWidgets('reducer required', (tester) async {
       await tester.pumpWidget(
         HookBuilder(
-          builder: (context) {
-            useReducer<void, void>(null);
+          builder: (context, h) {
+            h.useReducer<void, void>(null);
             return Container();
           },
         ),
@@ -91,8 +91,8 @@ void main() {
 
       await tester.pumpWidget(
         HookBuilder(
-          builder: (context) {
-            useReducer(reducer.call).dispatch('Foo');
+          builder: (context, h) {
+            h.useReducer(reducer.call).dispatch('Foo');
             return Container();
           },
         ),
@@ -107,12 +107,14 @@ void main() {
 
       await tester.pumpWidget(
         HookBuilder(
-          builder: (context) {
-            final result = useReducer(
-              reducer,
-              initialAction: 'Foo',
-              initialState: 0,
-            ).state;
+          builder: (context, h) {
+            final result = h
+                .useReducer(
+                  reducer,
+                  initialAction: 'Foo',
+                  initialState: 0,
+                )
+                .state;
             return Text('$result', textDirection: TextDirection.ltr);
           },
         ),
@@ -126,8 +128,8 @@ void main() {
       Store<int, String> store;
       Future<void> pump() {
         return tester.pumpWidget(HookBuilder(
-          builder: (context) {
-            store = useReducer(reducer);
+          builder: (context, h) {
+            store = h.useReducer(reducer);
             return Container();
           },
         ));
@@ -149,8 +151,8 @@ void main() {
 
       await tester.pumpWidget(
         HookBuilder(
-          builder: (context) {
-            useReducer(reducer.call);
+          builder: (context, h) {
+            h.useReducer(reducer.call);
             return Container();
           },
         ),

--- a/test/use_scroll_controller_test.dart
+++ b/test/use_scroll_controller_test.dart
@@ -10,8 +10,8 @@ import 'mock.dart';
 void main() {
   testWidgets('debugFillProperties', (tester) async {
     await tester.pumpWidget(
-      HookBuilder(builder: (context) {
-        useScrollController();
+      HookBuilder(builder: (context, h) {
+        h.useScrollController();
         return const SizedBox();
       }),
     );
@@ -36,9 +36,9 @@ void main() {
       ScrollController controller2;
 
       await tester.pumpWidget(
-        HookBuilder(builder: (context) {
+        HookBuilder(builder: (context, h) {
           controller2 = ScrollController();
-          controller = useScrollController();
+          controller = h.useScrollController();
           return Container();
         }),
       );
@@ -53,8 +53,8 @@ void main() {
       ScrollController controller2;
 
       await tester.pumpWidget(
-        HookBuilder(builder: (context) {
-          controller = useScrollController();
+        HookBuilder(builder: (context, h) {
+          controller = h.useScrollController();
           return Container();
         }),
       );
@@ -62,8 +62,8 @@ void main() {
       expect(controller, isA<ScrollController>());
 
       await tester.pumpWidget(
-        HookBuilder(builder: (context) {
-          controller2 = useScrollController();
+        HookBuilder(builder: (context, h) {
+          controller2 = h.useScrollController();
           return Container();
         }),
       );
@@ -77,8 +77,8 @@ void main() {
 
       await tester.pumpWidget(
         HookBuilder(
-          builder: (context) {
-            controller = useScrollController(
+          builder: (context, h) {
+            controller = h.useScrollController(
               initialScrollOffset: 42,
               debugLabel: 'Hello',
               keepScrollOffset: false,

--- a/test/use_state_test.dart
+++ b/test/use_state_test.dart
@@ -11,9 +11,9 @@ void main() {
     HookElement element;
 
     await tester.pumpWidget(HookBuilder(
-      builder: (context) {
+      builder: (context, h) {
         element = context as HookElement;
-        state = useState(42);
+        state = h.useState(42);
         return Container();
       },
     ));
@@ -45,9 +45,9 @@ void main() {
     HookElement element;
 
     await tester.pumpWidget(HookBuilder(
-      builder: (context) {
+      builder: (context, h) {
         element = context as HookElement;
-        state = useState();
+        state = h.useState();
         return Container();
       },
     ));
@@ -78,9 +78,9 @@ void main() {
     ValueNotifier<int> state;
     HookElement element;
     final hookWidget = HookBuilder(
-      builder: (context) {
+      builder: (context, h) {
         element = context as HookElement;
-        state = useState(0);
+        state = h.useState(0);
         return const SizedBox();
       },
     );

--- a/test/use_stream_controller_test.dart
+++ b/test/use_stream_controller_test.dart
@@ -9,8 +9,8 @@ import 'mock.dart';
 void main() {
   testWidgets('debugFillProperties', (tester) async {
     await tester.pumpWidget(
-      HookBuilder(builder: (context) {
-        useStreamController<int>();
+      HookBuilder(builder: (context, h) {
+        h.useStreamController<int>();
         return const SizedBox();
       }),
     );
@@ -37,14 +37,14 @@ void main() {
     testWidgets('keys', (tester) async {
       StreamController<int> controller;
 
-      await tester.pumpWidget(HookBuilder(builder: (context) {
-        controller = useStreamController();
+      await tester.pumpWidget(HookBuilder(builder: (context, h) {
+        controller = h.useStreamController();
         return Container();
       }));
 
       final previous = controller;
-      await tester.pumpWidget(HookBuilder(builder: (context) {
-        controller = useStreamController(keys: []);
+      await tester.pumpWidget(HookBuilder(builder: (context, h) {
+        controller = h.useStreamController(keys: []);
         return Container();
       }));
 
@@ -53,8 +53,8 @@ void main() {
     testWidgets('basics', (tester) async {
       StreamController<int> controller;
 
-      await tester.pumpWidget(HookBuilder(builder: (context) {
-        controller = useStreamController();
+      await tester.pumpWidget(HookBuilder(builder: (context, h) {
+        controller = h.useStreamController();
         return Container();
       }));
 
@@ -67,8 +67,8 @@ void main() {
       final previousController = controller;
       void onListen() {}
       void onCancel() {}
-      await tester.pumpWidget(HookBuilder(builder: (context) {
-        controller = useStreamController(
+      await tester.pumpWidget(HookBuilder(builder: (context, h) {
+        controller = h.useStreamController(
           sync: true,
           onCancel: onCancel,
           onListen: onListen,
@@ -90,8 +90,8 @@ void main() {
     testWidgets('sync', (tester) async {
       StreamController<int> controller;
 
-      await tester.pumpWidget(HookBuilder(builder: (context) {
-        controller = useStreamController(sync: true);
+      await tester.pumpWidget(HookBuilder(builder: (context, h) {
+        controller = h.useStreamController(sync: true);
         return Container();
       }));
 
@@ -104,8 +104,8 @@ void main() {
       final previousController = controller;
       void onListen() {}
       void onCancel() {}
-      await tester.pumpWidget(HookBuilder(builder: (context) {
-        controller = useStreamController(
+      await tester.pumpWidget(HookBuilder(builder: (context, h) {
+        controller = h.useStreamController(
           onCancel: onCancel,
           onListen: onListen,
         );

--- a/test/use_stream_test.dart
+++ b/test/use_stream_test.dart
@@ -15,8 +15,8 @@ void main() {
     final stream = Stream.value(42);
 
     await tester.pumpWidget(
-      HookBuilder(builder: (context) {
-        useStream(stream);
+      HookBuilder(builder: (context, h) {
+        h.useStream(stream);
         return const SizedBox();
       }),
     );
@@ -40,9 +40,9 @@ void main() {
   testWidgets('default preserve state, changing stream keeps previous value',
       (tester) async {
     AsyncSnapshot<int> value;
-    Widget Function(BuildContext) builder(Stream<int> stream) {
-      return (context) {
-        value = useStream(stream);
+    Widget Function(BuildContext, Hookable) builder(Stream<int> stream) {
+      return (context, h) {
+        value = h.useStream(stream);
         return Container();
       };
     }
@@ -62,9 +62,9 @@ void main() {
   testWidgets('If preserveState == false, changing stream resets value',
       (tester) async {
     AsyncSnapshot<int> value;
-    Widget Function(BuildContext) builder(Stream<int> stream) {
-      return (context) {
-        value = useStream(stream, preserveState: false);
+    Widget Function(BuildContext, Hookable) builder(Stream<int> stream) {
+      return (context, h) {
+        value = h.useStream(stream, preserveState: false);
         return Container();
       };
     }
@@ -82,10 +82,10 @@ void main() {
     expect(value.data, 42);
   });
 
-  Widget Function(BuildContext) snapshotText(Stream<String> stream,
+  Widget Function(BuildContext, Hookable) snapshotText(Stream<String> stream,
       {String initialData}) {
-    return (context) {
-      final snapshot = useStream(stream, initialData: initialData);
+    return (context, h) {
+      final snapshot = h.useStream(stream, initialData: initialData);
       return Text(snapshot.toString(), textDirection: TextDirection.ltr);
     };
   }

--- a/test/use_tab_controller_test.dart
+++ b/test/use_tab_controller_test.dart
@@ -10,8 +10,8 @@ import 'mock.dart';
 void main() {
   testWidgets('debugFillProperties', (tester) async {
     await tester.pumpWidget(
-      HookBuilder(builder: (context) {
-        useTabController(initialLength: 4);
+      HookBuilder(builder: (context, h) {
+        h.useTabController(initialLength: 4);
         return const SizedBox();
       }),
     );
@@ -39,10 +39,10 @@ void main() {
       TabController controller2;
 
       await tester.pumpWidget(
-        HookBuilder(builder: (context) {
-          final vsync = useSingleTickerProvider();
+        HookBuilder(builder: (context, h) {
+          final vsync = h.useSingleTickerProvider();
           controller2 = TabController(length: 4, vsync: vsync);
-          controller = useTabController(initialLength: 4);
+          controller = h.useTabController(initialLength: 4);
           return Container();
         }),
       );
@@ -54,8 +54,8 @@ void main() {
       TabController controller2;
 
       await tester.pumpWidget(
-        HookBuilder(builder: (context) {
-          controller = useTabController(initialLength: 1);
+        HookBuilder(builder: (context, h) {
+          controller = h.useTabController(initialLength: 1);
           return Container();
         }),
       );
@@ -63,8 +63,8 @@ void main() {
       expect(controller, isA<TabController>());
 
       await tester.pumpWidget(
-        HookBuilder(builder: (context) {
-          controller2 = useTabController(initialLength: 1);
+        HookBuilder(builder: (context, h) {
+          controller2 = h.useTabController(initialLength: 1);
           return Container();
         }),
       );
@@ -75,8 +75,8 @@ void main() {
       TabController controller;
 
       await tester.pumpWidget(
-        HookBuilder(builder: (context) {
-          controller = useTabController(initialLength: 1);
+        HookBuilder(builder: (context, h) {
+          controller = h.useTabController(initialLength: 1);
           return Container();
         }),
       );
@@ -84,8 +84,8 @@ void main() {
       expect(controller.length, 1);
 
       await tester.pumpWidget(
-        HookBuilder(builder: (context) {
-          controller = useTabController(initialLength: 2);
+        HookBuilder(builder: (context, h) {
+          controller = h.useTabController(initialLength: 2);
           return Container();
         }),
       );
@@ -98,8 +98,8 @@ void main() {
 
       await tester.pumpWidget(
         HookBuilder(
-          builder: (context) {
-            controller = useTabController(initialIndex: 2, initialLength: 4);
+          builder: (context, h) {
+            controller = h.useTabController(initialIndex: 2, initialLength: 4);
 
             return Container();
           },
@@ -116,8 +116,8 @@ void main() {
 
       await tester.pumpWidget(
         HookBuilder(
-          builder: (context) {
-            useTabController(initialLength: 1, vsync: vsync);
+          builder: (context, h) {
+            h.useTabController(initialLength: 1, vsync: vsync);
 
             return Container();
           },
@@ -129,8 +129,8 @@ void main() {
 
       await tester.pumpWidget(
         HookBuilder(
-          builder: (context) {
-            useTabController(initialLength: 1, vsync: vsync);
+          builder: (context, h) {
+            h.useTabController(initialLength: 1, vsync: vsync);
             return Container();
           },
         ),

--- a/test/use_text_editing_controller_test.dart
+++ b/test/use_text_editing_controller_test.dart
@@ -9,7 +9,7 @@ import 'mock.dart';
 void main() {
   testWidgets('debugFillProperties', (tester) async {
     await tester.pumpWidget(
-      HookBuilder(builder: (context) {
+      HookBuilder(builder: (context, h) {
         useTextEditingController();
         return const SizedBox();
       }),
@@ -40,9 +40,9 @@ void main() {
     TextEditingController controller;
 
     await tester.pumpWidget(HookBuilder(
-      builder: (context) {
+      builder: (context, h) {
         controller = useTextEditingController();
-        useValueListenable(rebuilder);
+        h.useValueListenable(rebuilder);
         return Container();
       },
     ));
@@ -74,9 +74,9 @@ void main() {
     var targetText = initialText;
 
     await tester.pumpWidget(HookBuilder(
-      builder: (context) {
+      builder: (context, h) {
         controller = useTextEditingController(text: targetText);
-        useValueListenable(rebuilder);
+        h.useValueListenable(rebuilder);
         return Container();
       },
     ));
@@ -93,7 +93,7 @@ void main() {
   testWidgets('useTextEditingController throws error on null value',
       (tester) async {
     await tester.pumpWidget(HookBuilder(
-      builder: (context) {
+      builder: (context, h) {
         try {
           useTextEditingController.fromValue(null);
         } catch (e) {
@@ -114,9 +114,9 @@ void main() {
     TextEditingController controller;
 
     await tester.pumpWidget(HookBuilder(
-      builder: (context) {
+      builder: (context, h) {
         controller = useTextEditingController.fromValue(targetValue);
-        useValueListenable(rebuilder);
+        h.useValueListenable(rebuilder);
         return Container();
       },
     ));

--- a/test/use_ticker_provider_test.dart
+++ b/test/use_ticker_provider_test.dart
@@ -8,8 +8,8 @@ import 'mock.dart';
 void main() {
   testWidgets('debugFillProperties', (tester) async {
     await tester.pumpWidget(
-      HookBuilder(builder: (context) {
-        useSingleTickerProvider();
+      HookBuilder(builder: (context, h) {
+        h.useSingleTickerProvider();
         return const SizedBox();
       }),
     );
@@ -35,8 +35,8 @@ void main() {
 
     await tester.pumpWidget(TickerMode(
       enabled: true,
-      child: HookBuilder(builder: (context) {
-        provider = useSingleTickerProvider();
+      child: HookBuilder(builder: (context, h) {
+        provider = h.useSingleTickerProvider();
         return Container();
       }),
     ));
@@ -53,8 +53,8 @@ void main() {
   });
 
   testWidgets('useSingleTickerProvider unused', (tester) async {
-    await tester.pumpWidget(HookBuilder(builder: (context) {
-      useSingleTickerProvider();
+    await tester.pumpWidget(HookBuilder(builder: (context, h) {
+      h.useSingleTickerProvider();
       return Container();
     }));
 
@@ -66,8 +66,8 @@ void main() {
 
     await tester.pumpWidget(TickerMode(
       enabled: true,
-      child: HookBuilder(builder: (context) {
-        provider = useSingleTickerProvider();
+      child: HookBuilder(builder: (context, h) {
+        provider = h.useSingleTickerProvider();
         return Container();
       }),
     ));
@@ -93,16 +93,16 @@ void main() {
     TickerProvider provider;
     List<Object> keys;
 
-    await tester.pumpWidget(HookBuilder(builder: (context) {
-      provider = useSingleTickerProvider(keys: keys);
+    await tester.pumpWidget(HookBuilder(builder: (context, h) {
+      provider = h.useSingleTickerProvider(keys: keys);
       return Container();
     }));
 
     final previousProvider = provider;
     keys = [];
 
-    await tester.pumpWidget(HookBuilder(builder: (context) {
-      provider = useSingleTickerProvider(keys: keys);
+    await tester.pumpWidget(HookBuilder(builder: (context, h) {
+      provider = h.useSingleTickerProvider(keys: keys);
       return Container();
     }));
 

--- a/test/use_value_changed_test.dart
+++ b/test/use_value_changed_test.dart
@@ -7,15 +7,15 @@ import 'mock.dart';
 void main() {
   testWidgets('diagnostics', (tester) async {
     await tester.pumpWidget(
-      HookBuilder(builder: (context) {
-        useValueChanged<int, int>(0, (_, __) => 21);
+      HookBuilder(builder: (context, h) {
+        h.useValueChanged<int, int>(0, (_, __) => 21);
         return const SizedBox();
       }),
     );
 
     await tester.pumpWidget(
-      HookBuilder(builder: (context) {
-        useValueChanged<int, int>(42, (_, __) => 21);
+      HookBuilder(builder: (context, h) {
+        h.useValueChanged<int, int>(42, (_, __) => 21);
         return const SizedBox();
       }),
     );
@@ -42,8 +42,8 @@ void main() {
 
     Future<void> pump() {
       return tester.pumpWidget(
-        HookBuilder(builder: (context) {
-          result = useValueChanged(value, _useValueChanged);
+        HookBuilder(builder: (context, h) {
+          result = h.useValueChanged(value, _useValueChanged);
           return Container();
         }),
       );
@@ -99,8 +99,8 @@ void main() {
 
   testWidgets('valueChanged required', (tester) async {
     await tester.pumpWidget(HookBuilder(
-      builder: (context) {
-        useValueChanged<int, int>(42, null);
+      builder: (context, h) {
+        h.useValueChanged<int, int>(42, null);
         return Container();
       },
     ));

--- a/test/use_value_listenable_test.dart
+++ b/test/use_value_listenable_test.dart
@@ -7,8 +7,8 @@ import 'mock.dart';
 void main() {
   testWidgets('diagnostics', (tester) async {
     await tester.pumpWidget(
-      HookBuilder(builder: (context) {
-        useValueListenable(ValueNotifier(0));
+      HookBuilder(builder: (context, h) {
+        h.useValueListenable(ValueNotifier(0));
         return const SizedBox();
       }),
     );
@@ -30,8 +30,8 @@ void main() {
   testWidgets('useValueListenable throws with null', (tester) async {
     await tester.pumpWidget(
       HookBuilder(
-        builder: (context) {
-          useValueListenable<void>(null);
+        builder: (context, h) {
+          h.useValueListenable<void>(null);
           return Container();
         },
       ),
@@ -45,8 +45,8 @@ void main() {
 
     Future<void> pump() {
       return tester.pumpWidget(HookBuilder(
-        builder: (context) {
-          result = useValueListenable(listenable);
+        builder: (context, h) {
+          result = h.useValueListenable(listenable);
           return Container();
         },
       ));

--- a/test/use_value_notifier_test.dart
+++ b/test/use_value_notifier_test.dart
@@ -7,8 +7,8 @@ import 'mock.dart';
 void main() {
   testWidgets('diagnostics', (tester) async {
     await tester.pumpWidget(
-      HookBuilder(builder: (context) {
-        useValueNotifier(0);
+      HookBuilder(builder: (context, h) {
+        h.useValueNotifier(0);
         return const SizedBox();
       }),
     );
@@ -34,9 +34,9 @@ void main() {
       final listener = MockListener();
 
       await tester.pumpWidget(HookBuilder(
-        builder: (context) {
+        builder: (context, h) {
           element = context as HookElement;
-          state = useValueNotifier(42);
+          state = h.useValueNotifier(42);
           return Container();
         },
       ));
@@ -76,9 +76,9 @@ void main() {
       final listener = MockListener();
 
       await tester.pumpWidget(HookBuilder(
-        builder: (context) {
+        builder: (context, h) {
           element = context as HookElement;
-          state = useValueNotifier();
+          state = h.useValueNotifier();
           return Container();
         },
       ));
@@ -117,16 +117,16 @@ void main() {
       ValueNotifier<int> previous;
 
       await tester.pumpWidget(HookBuilder(
-        builder: (context) {
-          state = useValueNotifier(42);
+        builder: (context, h) {
+          state = h.useValueNotifier(42);
           return Container();
         },
       ));
 
       await tester.pumpWidget(HookBuilder(
-        builder: (context) {
+        builder: (context, h) {
           previous = state;
-          state = useValueNotifier(42, [42]);
+          state = h.useValueNotifier(42, [42]);
           return Container();
         },
       ));
@@ -138,16 +138,16 @@ void main() {
       ValueNotifier<int> previous;
 
       await tester.pumpWidget(HookBuilder(
-        builder: (context) {
-          state = useValueNotifier(null, [42]);
+        builder: (context, h) {
+          state = h.useValueNotifier(null, [42]);
           return Container();
         },
       ));
 
       await tester.pumpWidget(HookBuilder(
-        builder: (context) {
+        builder: (context, h) {
           previous = state;
-          state = useValueNotifier(42, [42]);
+          state = h.useValueNotifier(42, [42]);
           return Container();
         },
       ));


### PR DESCRIPTION
This prevents runtime errors when use* methods are mistakenly called in
e.g. StatelessWidget (which can and has happened in production due to
otherwise innocent refactoring), instead catching them at compile time.