### PR TITLE
Change useStream Stream with nullable values

### DIFF
--- a/packages/flutter_hooks/lib/src/async.dart
+++ b/packages/flutter_hooks/lib/src/async.dart
@@ -124,7 +124,7 @@ class _FutureStateHook<T> extends HookState<AsyncSnapshot<T?>, _FutureHook<T>> {
 ///   * [Stream], the object listened.
 ///   * [useFuture], similar to [useStream] but for [Future].
 AsyncSnapshot<T?> useStream<T>(
-  Stream<T>? stream, {
+  Stream<T?>? stream, {
   T? initialData,
   bool preserveState = true,
 }) {
@@ -144,7 +144,7 @@ class _StreamHook<T> extends Hook<AsyncSnapshot<T?>> {
     required this.preserveState,
   });
 
-  final Stream<T>? stream;
+  final Stream<T?>? stream;
   final T? initialData;
   final bool preserveState;
 

--- a/packages/flutter_hooks/lib/src/async.dart
+++ b/packages/flutter_hooks/lib/src/async.dart
@@ -154,7 +154,7 @@ class _StreamHook<T> extends Hook<AsyncSnapshot<T?>> {
 
 /// a clone of [StreamBuilderBase] implementation
 class _StreamHookState<T> extends HookState<AsyncSnapshot<T?>, _StreamHook<T>> {
-  StreamSubscription<T>? _subscription;
+  StreamSubscription<T?>? _subscription;
   late AsyncSnapshot<T?> _summary = initial;
 
   @override
@@ -220,7 +220,7 @@ class _StreamHookState<T> extends HookState<AsyncSnapshot<T?>, _StreamHook<T>> {
   AsyncSnapshot<T?> afterConnected(AsyncSnapshot<T?> current) =>
       current.inState(ConnectionState.waiting);
 
-  AsyncSnapshot<T?> afterData(T data) {
+  AsyncSnapshot<T?> afterData(T? data) {
     return AsyncSnapshot<T?>.withData(ConnectionState.active, data);
   }
 


### PR DESCRIPTION
The Stream in `useStream()` should be able to accept null values, as there are streams (for example `FirebaseAuth.instance.authStateChanges()` returns `Stream<User?>`), which have null values in them. Also as the async snapshot already can return null, this shouldn't be a problem