### PR TITLE
Remove unused parameter in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,7 +232,7 @@ There are two ways to create a hook:
   to the console whenever the value changes:
 
   ```dart
-  ValueNotifier<T> useLoggedState<T>(BuildContext context, [T initialData]) {
+  ValueNotifier<T> useLoggedState<T>([T initialData]) {
     final result = useState<T>(initialData);
     useValueChanged(result.value, (_, __) {
       print(result.value);
@@ -250,7 +250,7 @@ There are two ways to create a hook:
   It is usually good practice to hide the class under a function as such:
 
   ```dart
-  Result useMyHook(BuildContext context) {
+  Result useMyHook() {
     return use(const _TimeAlive());
   }
   ```


### PR DESCRIPTION
Hi Remi,
Resolved this issue. #280

I fixed it by referring to [custom_hook_function.dart](https://github.com/rrousselGit/flutter_hooks/blob/6d590cd3204f0978b3d9cdc23435a5e279c73f55/packages/flutter_hooks/example/lib/custom_hook_function.dart#L36).
