### PR TITLE
Add `onKeyEvent` to `useFocusNode`

### DIFF
--- a/packages/flutter_hooks/lib/src/focus.dart
+++ b/packages/flutter_hooks/lib/src/focus.dart
@@ -7,6 +7,7 @@ part of 'hooks.dart';
 FocusNode useFocusNode({
   String? debugLabel,
   FocusOnKeyCallback? onKey,
+  FocusOnKeyEventCallback? onKeyEvent,
   bool skipTraversal = false,
   bool canRequestFocus = true,
   bool descendantsAreFocusable = true,
@@ -15,6 +16,7 @@ FocusNode useFocusNode({
     _FocusNodeHook(
       debugLabel: debugLabel,
       onKey: onKey,
+      onKeyEvent: onKeyEvent,
       skipTraversal: skipTraversal,
       canRequestFocus: canRequestFocus,
       descendantsAreFocusable: descendantsAreFocusable,
@@ -26,6 +28,7 @@ class _FocusNodeHook extends Hook<FocusNode> {
   const _FocusNodeHook({
     this.debugLabel,
     this.onKey,
+    this.onKeyEvent,
     required this.skipTraversal,
     required this.canRequestFocus,
     required this.descendantsAreFocusable,
@@ -33,6 +36,7 @@ class _FocusNodeHook extends Hook<FocusNode> {
 
   final String? debugLabel;
   final FocusOnKeyCallback? onKey;
+  final FocusOnKeyEventCallback? onKeyEvent;
   final bool skipTraversal;
   final bool canRequestFocus;
   final bool descendantsAreFocusable;
@@ -47,6 +51,7 @@ class _FocusNodeHookState extends HookState<FocusNode, _FocusNodeHook> {
   late final FocusNode _focusNode = FocusNode(
     debugLabel: hook.debugLabel,
     onKey: hook.onKey,
+    onKeyEvent: hook.onKeyEvent,
     skipTraversal: hook.skipTraversal,
     canRequestFocus: hook.canRequestFocus,
     descendantsAreFocusable: hook.descendantsAreFocusable,

--- a/packages/flutter_hooks/lib/src/focus.dart
+++ b/packages/flutter_hooks/lib/src/focus.dart
@@ -63,7 +63,9 @@ class _FocusNodeHookState extends HookState<FocusNode, _FocusNodeHook> {
       ..debugLabel = hook.debugLabel
       ..skipTraversal = hook.skipTraversal
       ..canRequestFocus = hook.canRequestFocus
-      ..descendantsAreFocusable = hook.descendantsAreFocusable;
+      ..descendantsAreFocusable = hook.descendantsAreFocusable
+      ..onKey = hook.onKey
+      ..onKeyEvent = hook.onKeyEvent;
   }
 
   @override

--- a/packages/flutter_hooks/test/use_focus_node_test.dart
+++ b/packages/flutter_hooks/test/use_focus_node_test.dart
@@ -132,6 +132,7 @@ void main() {
           canRequestFocus: false,
           descendantsAreFocusable: false,
         );
+
         return Container();
       }),
     );
@@ -139,17 +140,17 @@ void main() {
     await tester.pumpWidget(
       HookBuilder(builder: (_) {
         focusNode = useFocusNode(
-            debugLabel: 'Bar', onKey: onKey2, onKeyEvent: onKeyEvent2);
+          debugLabel: 'Bar',
+          onKey: onKey2,
+          onKeyEvent: onKeyEvent2,
+        );
+
         return Container();
       }),
     );
 
-    expect(focusNode.onKey, onKey, reason: 'onKey has no setter');
-    expect(
-      focusNode.onKeyEvent,
-      onKeyEvent,
-      reason: 'onKeyEvent has no setter',
-    );
+    expect(focusNode.onKey, onKey2);
+    expect(focusNode.onKeyEvent, onKeyEvent2);
     expect(focusNode.debugLabel, 'Bar');
     expect(focusNode.skipTraversal, false);
     expect(focusNode.canRequestFocus, true);

--- a/packages/flutter_hooks/test/use_focus_node_test.dart
+++ b/packages/flutter_hooks/test/use_focus_node_test.dart
@@ -84,12 +84,16 @@ void main() {
     KeyEventResult onKey(FocusNode node, RawKeyEvent event) =>
         KeyEventResult.ignored;
 
+    KeyEventResult onKeyEvent(FocusNode node, KeyEvent event) =>
+        KeyEventResult.ignored;
+
     late FocusNode focusNode;
     await tester.pumpWidget(
       HookBuilder(builder: (_) {
         focusNode = useFocusNode(
           debugLabel: 'Foo',
           onKey: onKey,
+          onKeyEvent: onKeyEvent,
           skipTraversal: true,
           canRequestFocus: false,
           descendantsAreFocusable: false,
@@ -100,6 +104,7 @@ void main() {
 
     expect(focusNode.debugLabel, 'Foo');
     expect(focusNode.onKey, onKey);
+    expect(focusNode.onKeyEvent, onKeyEvent);
     expect(focusNode.skipTraversal, true);
     expect(focusNode.canRequestFocus, false);
     expect(focusNode.descendantsAreFocusable, false);
@@ -111,12 +116,18 @@ void main() {
     KeyEventResult onKey2(FocusNode node, RawKeyEvent event) =>
         KeyEventResult.ignored;
 
+    KeyEventResult onKeyEvent(FocusNode node, KeyEvent event) =>
+        KeyEventResult.ignored;
+    KeyEventResult onKeyEvent2(FocusNode node, KeyEvent event) =>
+        KeyEventResult.ignored;
+
     late FocusNode focusNode;
     await tester.pumpWidget(
       HookBuilder(builder: (_) {
         focusNode = useFocusNode(
           debugLabel: 'Foo',
           onKey: onKey,
+          onKeyEvent: onKeyEvent,
           skipTraversal: true,
           canRequestFocus: false,
           descendantsAreFocusable: false,
@@ -128,14 +139,17 @@ void main() {
     await tester.pumpWidget(
       HookBuilder(builder: (_) {
         focusNode = useFocusNode(
-          debugLabel: 'Bar',
-          onKey: onKey2,
-        );
+            debugLabel: 'Bar', onKey: onKey2, onKeyEvent: onKeyEvent2);
         return Container();
       }),
     );
 
     expect(focusNode.onKey, onKey, reason: 'onKey has no setter');
+    expect(
+      focusNode.onKeyEvent,
+      onKeyEvent,
+      reason: 'onKeyEvent has no setter',
+    );
     expect(focusNode.debugLabel, 'Bar');
     expect(focusNode.skipTraversal, false);
     expect(focusNode.canRequestFocus, true);


### PR DESCRIPTION
# Summary
The `FocusNode` object has a `onKeyEvent` that is meant to replace the `onKey` callback which uses the legacy `RawKeyEvent` class.  This pull request simply adds the ability to also specify `onKeyEvent` with `useFocusNode()`

```dart
final focusNode = useFocusNode(onKeyEvent: (node, event) {
    // Do something with the keyboard event here
    return KeyEventResult.ignored;
});
```