### PR TITLE
fix link to example main.dart on pub.dev example tab

### DIFF
--- a/packages/flutter_hooks/example/pubspec.lock
+++ b/packages/flutter_hooks/example/pubspec.lock
@@ -201,7 +201,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.18.4"
+    version: "0.18.5"
   flutter_test:
     dependency: "direct dev"
     description: flutter

--- a/packages/flutter_hooks/pubspec.yaml
+++ b/packages/flutter_hooks/pubspec.yaml
@@ -1,6 +1,8 @@
 name: flutter_hooks
 description: A flutter implementation of React hooks. It adds a new kind of widget with enhanced code reuse.
 homepage: https://github.com/rrousselGit/flutter_hooks
+repository: https://github.com/rrousselGit/flutter_hooks/tree/master/packages/flutter_hooks
+issue_tracker: https://github.com/rrousselGit/flutter_hooks/issues
 version: 0.18.5
 
 environment:


### PR DESCRIPTION
Close #232 

See https://github.com/felangel/bloc/blob/master/packages/flutter_bloc/pubspec.yaml for reference.