### PR TITLE
Fix use_transformation_controller test file

### DIFF
--- a/packages/flutter_hooks/example/pubspec.lock
+++ b/packages/flutter_hooks/example/pubspec.lock
@@ -201,7 +201,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.18.5"
+    version: "0.18.5+1"
   flutter_test:
     dependency: "direct dev"
     description: flutter

--- a/packages/flutter_hooks/test/use_transformation_controller_test.dart
+++ b/packages/flutter_hooks/test/use_transformation_controller_test.dart
@@ -22,8 +22,13 @@ void main() {
           .toStringDeep(),
       equalsIgnoringHashCodes(
         'HookBuilder\n'
-        ' │ useTransformationController: TransformationController#00000(no clients)\n'
-        ' └SizedBox(renderObject: RenderConstrainedBox#00000)\n',
+            ' │ useTransformationController:\n'
+            ' │   TransformationController#00000([0] 1.0,0.0,0.0,0.0\n'
+            ' │   [1] 0.0,1.0,0.0,0.0\n'
+            ' │   [2] 0.0,0.0,1.0,0.0\n'
+            ' │   [3] 0.0,0.0,0.0,1.0\n'
+            ' │   )\n'
+            ' └SizedBox(renderObject: RenderConstrainedBox#00000)\n'
       ),
     );
   });


### PR DESCRIPTION
The test file for useTransformationController was not running because it was missing the _test post-fix.