### PR TITLE
Make useCallback hook's keys optional

### DIFF
--- a/packages/flutter_hooks/CHANGELOG.md
+++ b/packages/flutter_hooks/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased minor
 
 - Added `useSearchController` (thanks to @snapsl)
+- Keys on `useCallback` are now optional, to match `useMemoized` (thanks to @jezsung)
 
 ## 0.18.6
 

--- a/packages/flutter_hooks/lib/src/primitives.dart
+++ b/packages/flutter_hooks/lib/src/primitives.dart
@@ -42,9 +42,9 @@ ObjectRef<T> useRef<T>(T initialValue) {
 /// }, [key]);
 /// ```
 T useCallback<T extends Function>(
-  T callback,
-  List<Object?> keys,
-) {
+  T callback, [
+  List<Object?> keys = const <Object>[],
+]) {
   return useMemoized(() => callback, keys);
 }
 

--- a/packages/flutter_hooks/test/memoized_test.dart
+++ b/packages/flutter_hooks/test/memoized_test.dart
@@ -65,42 +65,6 @@ void main() {
         reason: 'The ref value has the last assigned value.');
   });
 
-  testWidgets('useCallback', (tester) async {
-    late int Function() fn;
-
-    await tester.pumpWidget(
-      HookBuilder(builder: (context) {
-        fn = useCallback<int Function()>(() => 42, []);
-        return Container();
-      }),
-    );
-
-    expect(fn(), 42);
-
-    late int Function() fn2;
-
-    await tester.pumpWidget(
-      HookBuilder(builder: (context) {
-        fn2 = useCallback<int Function()>(() => 42, []);
-        return Container();
-      }),
-    );
-
-    expect(fn2, fn);
-
-    late int Function() fn3;
-
-    await tester.pumpWidget(
-      HookBuilder(builder: (context) {
-        fn3 = useCallback<int Function()>(() => 21, [42]);
-        return Container();
-      }),
-    );
-
-    expect(fn3, isNot(fn));
-    expect(fn3(), 21);
-  });
-
   testWidgets('memoized without parameter calls valueBuilder once',
       (tester) async {
     late int result;

--- a/packages/flutter_hooks/test/use_callback_test.dart
+++ b/packages/flutter_hooks/test/use_callback_test.dart
@@ -4,6 +4,42 @@ import 'package:flutter_hooks/flutter_hooks.dart';
 import 'mock.dart';
 
 void main() {
+  testWidgets('useCallback', (tester) async {
+    late int Function() fn;
+
+    await tester.pumpWidget(
+      HookBuilder(builder: (context) {
+        fn = useCallback<int Function()>(() => 42, []);
+        return Container();
+      }),
+    );
+
+    expect(fn(), 42);
+
+    late int Function() fn2;
+
+    await tester.pumpWidget(
+      HookBuilder(builder: (context) {
+        fn2 = useCallback<int Function()>(() => 42, []);
+        return Container();
+      }),
+    );
+
+    expect(fn2, fn);
+
+    late int Function() fn3;
+
+    await tester.pumpWidget(
+      HookBuilder(builder: (context) {
+        fn3 = useCallback<int Function()>(() => 21, [42]);
+        return Container();
+      }),
+    );
+
+    expect(fn3, isNot(fn));
+    expect(fn3(), 21);
+  });
+
   testWidgets(
     'should return same function when keys are not specified',
     (tester) async {

--- a/packages/flutter_hooks/test/use_callback_test.dart
+++ b/packages/flutter_hooks/test/use_callback_test.dart
@@ -1,0 +1,36 @@
+import 'package:flutter/widgets.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
+
+import 'mock.dart';
+
+void main() {
+  testWidgets(
+    'should return same function when keys are not specified',
+    (tester) async {
+      late Function fn1;
+      late Function fn2;
+
+      await tester.pumpWidget(
+        HookBuilder(
+          key: const Key('hook_builder'),
+          builder: (context) {
+            fn1 = useCallback(() {});
+            return Container();
+          },
+        ),
+      );
+
+      await tester.pumpWidget(
+        HookBuilder(
+          key: const Key('hook_builder'),
+          builder: (context) {
+            fn2 = useCallback(() {});
+            return Container();
+          },
+        ),
+      );
+
+      expect(fn1, same(fn2));
+    },
+  );
+}


### PR DESCRIPTION
Makes the `useCallback` hook's `keys` property optional and default to an empty list.