### PR TITLE
Add useStreamSubscription hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -314,6 +314,7 @@ They will take care of creating/updating/disposing an object.
 | ---------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------- |
 | [useStream](https://pub.dev/documentation/flutter_hooks/latest/flutter_hooks/useStream.html)                     | Subscribes to a `Stream` and returns its current state as an `AsyncSnapshot`. |
 | [useStreamController](https://pub.dev/documentation/flutter_hooks/latest/flutter_hooks/useStreamController.html) | Creates a `StreamController` which will automatically be disposed.            |
+| [useOnStreamChange](https://pub.dev/documentation/flutter_hooks/latest/flutter_hooks/useOnStreamChange.html) | Subscribes to a `Stream`, registers handlers, and returns the `StreamSubscription`.
 | [useFuture](https://pub.dev/documentation/flutter_hooks/latest/flutter_hooks/useFuture.html)                     | Subscribes to a `Future` and returns its current state as an `AsyncSnapshot`. |
 
 #### Animation related hooks:

--- a/packages/flutter_hooks/lib/src/async.dart
+++ b/packages/flutter_hooks/lib/src/async.dart
@@ -392,8 +392,9 @@ class _StreamListenerHookState<T>
   }
 
   void _subscribe() {
-    if (hook.stream != null) {
-      _subscription = hook.stream!.listen(
+    final stream = hook.stream;
+    if (stream != null) {
+      _subscription = stream.listen(
         hook.onData?.call,
         onError: hook.onError?.call,
         onDone: hook.onDone?.call,

--- a/packages/flutter_hooks/lib/src/async.dart
+++ b/packages/flutter_hooks/lib/src/async.dart
@@ -395,9 +395,9 @@ class _StreamListenerHookState<T>
     final stream = hook.stream;
     if (stream != null) {
       _subscription = stream.listen(
-        hook.onData?.call,
-        onError: hook.onError?.call,
-        onDone: hook.onDone?.call,
+        hook.onData,
+        onError: hook.onError,
+        onDone: hook.onDone,
         cancelOnError: hook.cancelOnError,
       );
     }

--- a/packages/flutter_hooks/lib/src/async.dart
+++ b/packages/flutter_hooks/lib/src/async.dart
@@ -329,7 +329,7 @@ class _StreamControllerHookState<T>
 /// See also:
 ///   * [Stream], the object listened.
 ///   * [Stream.listen], calls the provided handlers.
-StreamSubscription<T> useStreamSubscription<T>(
+StreamSubscription<T> useOnStreamChange<T>(
   Stream<T> stream, {
   void Function(T event)? onData,
   void Function(Object error, StackTrace stackTrace)? onError,
@@ -337,7 +337,7 @@ StreamSubscription<T> useStreamSubscription<T>(
   bool? cancelOnError,
 }) {
   return use<StreamSubscription<T>>(
-    _StreamSubscriptionHook<T>(
+    _OnStreamChangeHook<T>(
       stream,
       onData: onData,
       onError: onError,
@@ -347,8 +347,8 @@ StreamSubscription<T> useStreamSubscription<T>(
   );
 }
 
-class _StreamSubscriptionHook<T> extends Hook<StreamSubscription<T>> {
-  const _StreamSubscriptionHook(
+class _OnStreamChangeHook<T> extends Hook<StreamSubscription<T>> {
+  const _OnStreamChangeHook(
     this.stream, {
     this.onData,
     this.onError,
@@ -367,7 +367,7 @@ class _StreamSubscriptionHook<T> extends Hook<StreamSubscription<T>> {
 }
 
 class _StreamListenerHookState<T>
-    extends HookState<StreamSubscription<T>, _StreamSubscriptionHook<T>> {
+    extends HookState<StreamSubscription<T>, _OnStreamChangeHook<T>> {
   late StreamSubscription<T> _subscription;
 
   @override
@@ -377,7 +377,7 @@ class _StreamListenerHookState<T>
   }
 
   @override
-  void didUpdateHook(_StreamSubscriptionHook<T> oldWidget) {
+  void didUpdateHook(_OnStreamChangeHook<T> oldWidget) {
     super.didUpdateHook(oldWidget);
     if (oldWidget.stream != hook.stream ||
         oldWidget.cancelOnError != hook.cancelOnError) {
@@ -410,5 +410,5 @@ class _StreamListenerHookState<T>
   }
 
   @override
-  String get debugLabel => 'useStreamSubscription';
+  String get debugLabel => 'useOnStreamChange';
 }

--- a/packages/flutter_hooks/lib/src/async.dart
+++ b/packages/flutter_hooks/lib/src/async.dart
@@ -329,14 +329,14 @@ class _StreamControllerHookState<T>
 /// See also:
 ///   * [Stream], the object listened.
 ///   * [Stream.listen], calls the provided handlers.
-StreamSubscription<T> useOnStreamChange<T>(
-  Stream<T> stream, {
+StreamSubscription<T>? useOnStreamChange<T>(
+  Stream<T>? stream, {
   void Function(T event)? onData,
   void Function(Object error, StackTrace stackTrace)? onError,
   void Function()? onDone,
   bool? cancelOnError,
 }) {
-  return use<StreamSubscription<T>>(
+  return use<StreamSubscription<T>?>(
     _OnStreamChangeHook<T>(
       stream,
       onData: onData,
@@ -347,7 +347,7 @@ StreamSubscription<T> useOnStreamChange<T>(
   );
 }
 
-class _OnStreamChangeHook<T> extends Hook<StreamSubscription<T>> {
+class _OnStreamChangeHook<T> extends Hook<StreamSubscription<T>?> {
   const _OnStreamChangeHook(
     this.stream, {
     this.onData,
@@ -356,7 +356,7 @@ class _OnStreamChangeHook<T> extends Hook<StreamSubscription<T>> {
     this.cancelOnError,
   });
 
-  final Stream<T> stream;
+  final Stream<T>? stream;
   final void Function(T event)? onData;
   final void Function(Object error, StackTrace stackTrace)? onError;
   final void Function()? onDone;
@@ -367,8 +367,8 @@ class _OnStreamChangeHook<T> extends Hook<StreamSubscription<T>> {
 }
 
 class _StreamListenerHookState<T>
-    extends HookState<StreamSubscription<T>, _OnStreamChangeHook<T>> {
-  late StreamSubscription<T> _subscription;
+    extends HookState<StreamSubscription<T>?, _OnStreamChangeHook<T>> {
+  StreamSubscription<T>? _subscription;
 
   @override
   void initHook() {
@@ -392,20 +392,22 @@ class _StreamListenerHookState<T>
   }
 
   void _subscribe() {
-    _subscription = hook.stream.listen(
-      hook.onData?.call,
-      onError: hook.onError?.call,
-      onDone: hook.onDone?.call,
-      cancelOnError: hook.cancelOnError,
-    );
+    if (hook.stream != null) {
+      _subscription = hook.stream!.listen(
+        hook.onData?.call,
+        onError: hook.onError?.call,
+        onDone: hook.onDone?.call,
+        cancelOnError: hook.cancelOnError,
+      );
+    }
   }
 
   void _unsubscribe() {
-    _subscription.cancel();
+    _subscription?.cancel();
   }
 
   @override
-  StreamSubscription<T> build(BuildContext context) {
+  StreamSubscription<T>? build(BuildContext context) {
     return _subscription;
   }
 

--- a/packages/flutter_hooks/test/use_on_stream_change_test.dart
+++ b/packages/flutter_hooks/test/use_on_stream_change_test.dart
@@ -7,214 +7,196 @@ import 'package:flutter_hooks/flutter_hooks.dart';
 import 'mock.dart';
 
 void main() {
-  testWidgets(
-    'debugFillProperties',
-    (tester) async {
-      final stream = Stream.value(42);
+  testWidgets('debugFillProperties', (tester) async {
+    final stream = Stream.value(42);
 
-      await tester.pumpWidget(
-        HookBuilder(builder: (context) {
-          useOnStreamChange(stream);
-          return const SizedBox();
-        }),
-      );
+    await tester.pumpWidget(
+      HookBuilder(builder: (context) {
+        useOnStreamChange(stream);
+        return const SizedBox();
+      }),
+    );
 
-      await tester.pump();
+    await tester.pump();
 
-      final element = tester.element(find.byType(HookBuilder));
+    final element = tester.element(find.byType(HookBuilder));
 
-      expect(
-        element
-            .toDiagnosticsNode(style: DiagnosticsTreeStyle.offstage)
-            .toStringDeep(),
-        equalsIgnoringHashCodes(
-          'HookBuilder\n'
-          " │ useOnStreamChange: Instance of '_ControllerSubscription<int>'\n"
-          ' └SizedBox(renderObject: RenderConstrainedBox#00000)\n',
-        ),
-      );
-    },
-  );
+    expect(
+      element
+          .toDiagnosticsNode(style: DiagnosticsTreeStyle.offstage)
+          .toStringDeep(),
+      equalsIgnoringHashCodes(
+        'HookBuilder\n'
+        " │ useOnStreamChange: Instance of '_ControllerSubscription<int>'\n"
+        ' └SizedBox(renderObject: RenderConstrainedBox#00000)\n',
+      ),
+    );
+  });
 
-  testWidgets(
-    'calls onData when data arrives',
-    (tester) async {
-      const data = 42;
-      final stream = Stream<int>.value(data);
+  testWidgets('calls onData when data arrives', (tester) async {
+    const data = 42;
+    final stream = Stream<int>.value(data);
 
-      late int value;
+    late int value;
 
-      await tester.pumpWidget(
-        HookBuilder(builder: (context) {
-          useOnStreamChange<int>(
-            stream,
-            onData: (data) {
-              value = data;
-            },
-          );
-          return const SizedBox();
-        }),
-      );
-
-      expect(value, data);
-    },
-  );
-
-  testWidgets(
-    'calls onError when error occurs',
-    (tester) async {
-      final error = Exception();
-      final stream = Stream<int>.error(error);
-
-      late Object receivedError;
-
-      await tester.pumpWidget(
-        HookBuilder(builder: (context) {
-          useOnStreamChange<int>(
-            stream,
-            onError: (error, stackTrace) {
-              receivedError = error;
-            },
-          );
-          return const SizedBox();
-        }),
-      );
-
-      expect(receivedError, same(error));
-    },
-  );
-
-  testWidgets(
-    'calls onDone when stream is closed',
-    (tester) async {
-      final streamController = StreamController<int>.broadcast();
-
-      var onDoneCalled = false;
-
-      await tester.pumpWidget(
-        HookBuilder(builder: (context) {
-          useOnStreamChange<int>(
-            streamController.stream,
-            onDone: () {
-              onDoneCalled = true;
-            },
-          );
-          return const SizedBox();
-        }),
-      );
-
-      await streamController.close();
-
-      expect(onDoneCalled, isTrue);
-    },
-  );
-
-  testWidgets(
-    'cancels subscription when cancelOnError is true and error occurrs',
-    (tester) async {
-      // ignore: close_sinks
-      final streamController = StreamController<int>();
-
-      await tester.pumpWidget(
-        HookBuilder(builder: (context) {
-          useOnStreamChange<int>(
-            streamController.stream,
-            // onError needs to be set to prevent unhandled errors from propagating.
-            onError: (error, stackTrace) {},
-            cancelOnError: true,
-          );
-          return const SizedBox();
-        }),
-      );
-
-      expect(streamController.hasListener, isTrue);
-
-      streamController.addError(Exception());
-
-      await tester.pump();
-
-      expect(streamController.hasListener, isFalse);
-    },
-  );
-
-  testWidgets(
-    'listens new stream when stream is changed',
-    (tester) async {
-      const value1 = 42;
-      const value2 = 43;
-
-      final stream1 = Stream<int>.value(value1);
-      final stream2 = Stream<int>.value(value2);
-
-      late int receivedValue;
-
-      await tester.pumpWidget(
-        HookBuilder(
-          key: const Key('hook_builder'),
-          builder: (context) {
-            useOnStreamChange<int>(
-              stream1,
-              onData: (data) => receivedValue = data,
-            );
-            return const SizedBox();
+    await tester.pumpWidget(
+      HookBuilder(builder: (context) {
+        useOnStreamChange<int>(
+          stream,
+          onData: (data) {
+            value = data;
           },
-        ),
-      );
+        );
+        return const SizedBox();
+      }),
+    );
 
-      expect(receivedValue, value1);
+    expect(value, data);
+  });
 
-      // Listens to the stream2
-      await tester.pumpWidget(
-        HookBuilder(
-          key: const Key('hook_builder'),
-          builder: (context) {
-            useOnStreamChange<int>(
-              stream2,
-              onData: (data) => receivedValue = data,
-            );
-            return const SizedBox();
+  testWidgets('calls onError when error occurs', (tester) async {
+    final error = Exception();
+    final stream = Stream<int>.error(error);
+
+    late Object receivedError;
+
+    await tester.pumpWidget(
+      HookBuilder(builder: (context) {
+        useOnStreamChange<int>(
+          stream,
+          onError: (error, stackTrace) {
+            receivedError = error;
           },
-        ),
-      );
+        );
+        return const SizedBox();
+      }),
+    );
 
-      expect(receivedValue, value2);
-    },
-  );
+    expect(receivedError, same(error));
+  });
+
+  testWidgets('calls onDone when stream is closed', (tester) async {
+    final streamController = StreamController<int>.broadcast();
+
+    var onDoneCalled = false;
+
+    await tester.pumpWidget(
+      HookBuilder(builder: (context) {
+        useOnStreamChange<int>(
+          streamController.stream,
+          onDone: () {
+            onDoneCalled = true;
+          },
+        );
+        return const SizedBox();
+      }),
+    );
+
+    await streamController.close();
+
+    expect(onDoneCalled, isTrue);
+  });
 
   testWidgets(
-    'stop listening when cancel is called on StreamSubscription',
-    (tester) async {
-      final controller = StreamController<int>();
-      late StreamSubscription<int> subscription;
+      'cancels subscription when cancelOnError is true and error occurrs',
+      (tester) async {
+    // ignore: close_sinks
+    final streamController = StreamController<int>();
 
-      const value1 = 42;
+    await tester.pumpWidget(
+      HookBuilder(builder: (context) {
+        useOnStreamChange<int>(
+          streamController.stream,
+          // onError needs to be set to prevent unhandled errors from propagating.
+          onError: (error, stackTrace) {},
+          cancelOnError: true,
+        );
+        return const SizedBox();
+      }),
+    );
 
-      var receivedValue = 0;
+    expect(streamController.hasListener, isTrue);
 
-      await tester.pumpWidget(
-        HookBuilder(
-          key: const Key('hook_builder'),
-          builder: (context) {
-            subscription = useOnStreamChange<int>(
-              controller.stream,
-              onData: (data) => receivedValue = data,
-            );
-            return const SizedBox();
-          },
-        ),
-      );
+    streamController.addError(Exception());
 
-      // Awaiting on subscription.cancel never ends.
-      // Needs to be checked if this is expected.
-      unawaited(subscription.cancel());
+    await tester.pump();
 
-      controller.add(value1);
+    expect(streamController.hasListener, isFalse);
+  });
 
-      await tester.pump();
+  testWidgets('listens new stream when stream is changed', (tester) async {
+    const value1 = 42;
+    const value2 = 43;
 
-      expect(receivedValue, isZero);
+    final stream1 = Stream<int>.value(value1);
+    final stream2 = Stream<int>.value(value2);
 
-      unawaited(controller.close());
-    },
-  );
+    late int receivedValue;
+
+    await tester.pumpWidget(
+      HookBuilder(
+        key: const Key('hook_builder'),
+        builder: (context) {
+          useOnStreamChange<int>(
+            stream1,
+            onData: (data) => receivedValue = data,
+          );
+          return const SizedBox();
+        },
+      ),
+    );
+
+    expect(receivedValue, value1);
+
+    // Listens to the stream2
+    await tester.pumpWidget(
+      HookBuilder(
+        key: const Key('hook_builder'),
+        builder: (context) {
+          useOnStreamChange<int>(
+            stream2,
+            onData: (data) => receivedValue = data,
+          );
+          return const SizedBox();
+        },
+      ),
+    );
+
+    expect(receivedValue, value2);
+  });
+
+  testWidgets('stop listening when cancel is called on StreamSubscription',
+      (tester) async {
+    final controller = StreamController<int>();
+    late StreamSubscription<int> subscription;
+
+    const value1 = 42;
+
+    var receivedValue = 0;
+
+    await tester.pumpWidget(
+      HookBuilder(
+        key: const Key('hook_builder'),
+        builder: (context) {
+          subscription = useOnStreamChange<int>(
+            controller.stream,
+            onData: (data) => receivedValue = data,
+          );
+          return const SizedBox();
+        },
+      ),
+    );
+
+    // Awaiting on subscription.cancel never ends.
+    // Needs to be checked if this is expected.
+    unawaited(subscription.cancel());
+
+    controller.add(value1);
+
+    await tester.pump();
+
+    expect(receivedValue, isZero);
+
+    unawaited(controller.close());
+  });
 }

--- a/packages/flutter_hooks/test/use_on_stream_change_test.dart
+++ b/packages/flutter_hooks/test/use_on_stream_change_test.dart
@@ -217,21 +217,15 @@ void main() {
   testWidgets(
     'stop listening when cancel is called on StreamSubscription',
     (tester) => tester.runAsync(() async {
-      final controller = StreamController<int>();
+      final streamController = StreamController<int>();
+
       late StreamSubscription<int> subscription;
-
-      const value1 = 42;
-
-      var receivedValue = 0;
 
       await tester.pumpWidget(
         HookBuilder(
           key: const Key('hook_builder'),
           builder: (context) {
-            subscription = useOnStreamChange<int>(
-              controller.stream,
-              onData: (data) => receivedValue = data,
-            );
+            subscription = useOnStreamChange<int>(streamController.stream);
             return const SizedBox();
           },
         ),
@@ -239,13 +233,9 @@ void main() {
 
       await subscription.cancel();
 
-      controller.add(value1);
+      expect(streamController.hasListener, isFalse);
 
-      await tester.pump();
-
-      expect(receivedValue, isZero);
-
-      await controller.close();
+      await streamController.close();
     }),
   );
 }

--- a/packages/flutter_hooks/test/use_on_stream_change_test.dart
+++ b/packages/flutter_hooks/test/use_on_stream_change_test.dart
@@ -14,7 +14,7 @@ void main() {
 
       await tester.pumpWidget(
         HookBuilder(builder: (context) {
-          useStreamSubscription(stream);
+          useOnStreamChange(stream);
           return const SizedBox();
         }),
       );
@@ -29,7 +29,7 @@ void main() {
             .toStringDeep(),
         equalsIgnoringHashCodes(
           'HookBuilder\n'
-          " │ useStreamSubscription: Instance of '_ControllerSubscription<int>'\n"
+          " │ useOnStreamChange: Instance of '_ControllerSubscription<int>'\n"
           ' └SizedBox(renderObject: RenderConstrainedBox#00000)\n',
         ),
       );
@@ -46,7 +46,7 @@ void main() {
 
       await tester.pumpWidget(
         HookBuilder(builder: (context) {
-          useStreamSubscription<int>(
+          useOnStreamChange<int>(
             stream,
             onData: (data) {
               value = data;
@@ -70,7 +70,7 @@ void main() {
 
       await tester.pumpWidget(
         HookBuilder(builder: (context) {
-          useStreamSubscription<int>(
+          useOnStreamChange<int>(
             stream,
             onError: (error, stackTrace) {
               receivedError = error;
@@ -93,7 +93,7 @@ void main() {
 
       await tester.pumpWidget(
         HookBuilder(builder: (context) {
-          useStreamSubscription<int>(
+          useOnStreamChange<int>(
             streamController.stream,
             onDone: () {
               onDoneCalled = true;
@@ -117,7 +117,7 @@ void main() {
 
       await tester.pumpWidget(
         HookBuilder(builder: (context) {
-          useStreamSubscription<int>(
+          useOnStreamChange<int>(
             streamController.stream,
             // onError needs to be set to prevent unhandled errors from propagating.
             onError: (error, stackTrace) {},
@@ -152,7 +152,7 @@ void main() {
         HookBuilder(
           key: const Key('hook_builder'),
           builder: (context) {
-            useStreamSubscription<int>(
+            useOnStreamChange<int>(
               stream1,
               onData: (data) => receivedValue = data,
             );
@@ -168,7 +168,7 @@ void main() {
         HookBuilder(
           key: const Key('hook_builder'),
           builder: (context) {
-            useStreamSubscription<int>(
+            useOnStreamChange<int>(
               stream2,
               onData: (data) => receivedValue = data,
             );
@@ -195,7 +195,7 @@ void main() {
         HookBuilder(
           key: const Key('hook_builder'),
           builder: (context) {
-            subscription = useStreamSubscription<int>(
+            subscription = useOnStreamChange<int>(
               controller.stream,
               onData: (data) => receivedValue = data,
             );

--- a/packages/flutter_hooks/test/use_on_stream_change_test.dart
+++ b/packages/flutter_hooks/test/use_on_stream_change_test.dart
@@ -214,38 +214,38 @@ void main() {
     }),
   );
 
-  testWidgets('stop listening when cancel is called on StreamSubscription',
-      (tester) async {
-    final controller = StreamController<int>();
-    late StreamSubscription<int> subscription;
+  testWidgets(
+    'stop listening when cancel is called on StreamSubscription',
+    (tester) => tester.runAsync(() async {
+      final controller = StreamController<int>();
+      late StreamSubscription<int> subscription;
 
-    const value1 = 42;
+      const value1 = 42;
 
-    var receivedValue = 0;
+      var receivedValue = 0;
 
-    await tester.pumpWidget(
-      HookBuilder(
-        key: const Key('hook_builder'),
-        builder: (context) {
-          subscription = useOnStreamChange<int>(
-            controller.stream,
-            onData: (data) => receivedValue = data,
-          );
-          return const SizedBox();
-        },
-      ),
-    );
+      await tester.pumpWidget(
+        HookBuilder(
+          key: const Key('hook_builder'),
+          builder: (context) {
+            subscription = useOnStreamChange<int>(
+              controller.stream,
+              onData: (data) => receivedValue = data,
+            );
+            return const SizedBox();
+          },
+        ),
+      );
 
-    // Awaiting on subscription.cancel never ends.
-    // Needs to be checked if this is expected.
-    unawaited(subscription.cancel());
+      await subscription.cancel();
 
-    controller.add(value1);
+      controller.add(value1);
 
-    await tester.pump();
+      await tester.pump();
 
-    expect(receivedValue, isZero);
+      expect(receivedValue, isZero);
 
-    unawaited(controller.close());
-  });
+      await controller.close();
+    }),
+  );
 }

--- a/packages/flutter_hooks/test/use_on_stream_change_test.dart
+++ b/packages/flutter_hooks/test/use_on_stream_change_test.dart
@@ -98,31 +98,33 @@ void main() {
   });
 
   testWidgets(
-      'cancels subscription when cancelOnError is true and error occurrs',
-      (tester) async {
-    // ignore: close_sinks
-    final streamController = StreamController<int>();
+    'cancels subscription when cancelOnError is true and error occurrs',
+    (tester) => tester.runAsync(() async {
+      final streamController = StreamController<int>();
 
-    await tester.pumpWidget(
-      HookBuilder(builder: (context) {
-        useOnStreamChange<int>(
-          streamController.stream,
-          // onError needs to be set to prevent unhandled errors from propagating.
-          onError: (error, stackTrace) {},
-          cancelOnError: true,
-        );
-        return const SizedBox();
-      }),
-    );
+      await tester.pumpWidget(
+        HookBuilder(builder: (context) {
+          useOnStreamChange<int>(
+            streamController.stream,
+            // onError needs to be set to prevent unhandled errors from propagating.
+            onError: (error, stackTrace) {},
+            cancelOnError: true,
+          );
+          return const SizedBox();
+        }),
+      );
 
-    expect(streamController.hasListener, isTrue);
+      expect(streamController.hasListener, isTrue);
 
-    streamController.addError(Exception());
+      streamController.addError(Exception());
 
-    await tester.pump();
+      await tester.pump();
 
-    expect(streamController.hasListener, isFalse);
-  });
+      expect(streamController.hasListener, isFalse);
+
+      await streamController.close();
+    }),
+  );
 
   testWidgets(
     'listens new stream when stream is changed',

--- a/packages/flutter_hooks/test/use_on_stream_change_test.dart
+++ b/packages/flutter_hooks/test/use_on_stream_change_test.dart
@@ -139,7 +139,7 @@ void main() {
         HookBuilder(
           key: const Key('hook_builder'),
           builder: (context) {
-            subscription1 = useOnStreamChange<int>(streamController1.stream);
+            subscription1 = useOnStreamChange<int>(streamController1.stream)!;
             return const SizedBox();
           },
         ),
@@ -152,7 +152,7 @@ void main() {
         HookBuilder(
           key: const Key('hook_builder'),
           builder: (context) {
-            subscription2 = useOnStreamChange<int>(streamController2.stream);
+            subscription2 = useOnStreamChange<int>(streamController2.stream)!;
             return const SizedBox();
           },
         ),
@@ -227,7 +227,7 @@ void main() {
         HookBuilder(
           key: const Key('hook_builder'),
           builder: (context) {
-            subscription = useOnStreamChange<int>(streamController.stream);
+            subscription = useOnStreamChange<int>(streamController.stream)!;
             return const SizedBox();
           },
         ),
@@ -236,6 +236,56 @@ void main() {
       await subscription.cancel();
 
       expect(streamController.hasListener, isFalse);
+
+      await streamController.close();
+    }),
+  );
+
+  testWidgets('returns null when stream is null', (tester) async {
+    StreamSubscription<int>? subscription;
+
+    await tester.pumpWidget(
+      HookBuilder(builder: (context) {
+        subscription = useOnStreamChange<int>(null);
+        return const SizedBox();
+      }),
+    );
+
+    expect(subscription, isNull);
+  });
+
+  testWidgets(
+    'unsubscribes when stream changed to null',
+    (tester) => tester.runAsync(() async {
+      final streamController = StreamController<int>();
+
+      StreamSubscription<int>? subscription;
+
+      await tester.pumpWidget(
+        HookBuilder(
+          key: const Key('hook_builder'),
+          builder: (context) {
+            subscription = useOnStreamChange<int>(streamController.stream);
+            return const SizedBox();
+          },
+        ),
+      );
+
+      expect(streamController.hasListener, isTrue);
+      expect(subscription, isNotNull);
+
+      await tester.pumpWidget(
+        HookBuilder(
+          key: const Key('hook_builder'),
+          builder: (context) {
+            subscription = useOnStreamChange<int>(null);
+            return const SizedBox();
+          },
+        ),
+      );
+
+      expect(streamController.hasListener, isFalse);
+      expect(subscription, isNotNull);
 
       await streamController.close();
     }),

--- a/packages/flutter_hooks/test/use_stream_subscription_test.dart
+++ b/packages/flutter_hooks/test/use_stream_subscription_test.dart
@@ -1,0 +1,220 @@
+import 'dart:async';
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
+
+import 'mock.dart';
+
+void main() {
+  testWidgets(
+    'debugFillProperties',
+    (tester) async {
+      final stream = Stream.value(42);
+
+      await tester.pumpWidget(
+        HookBuilder(builder: (context) {
+          useStreamSubscription(stream);
+          return const SizedBox();
+        }),
+      );
+
+      await tester.pump();
+
+      final element = tester.element(find.byType(HookBuilder));
+
+      expect(
+        element
+            .toDiagnosticsNode(style: DiagnosticsTreeStyle.offstage)
+            .toStringDeep(),
+        equalsIgnoringHashCodes(
+          'HookBuilder\n'
+          " │ useStreamSubscription: Instance of '_ControllerSubscription<int>'\n"
+          ' └SizedBox(renderObject: RenderConstrainedBox#00000)\n',
+        ),
+      );
+    },
+  );
+
+  testWidgets(
+    'calls onData when data arrives',
+    (tester) async {
+      const data = 42;
+      final stream = Stream<int>.value(data);
+
+      late int value;
+
+      await tester.pumpWidget(
+        HookBuilder(builder: (context) {
+          useStreamSubscription<int>(
+            stream,
+            onData: (data) {
+              value = data;
+            },
+          );
+          return const SizedBox();
+        }),
+      );
+
+      expect(value, data);
+    },
+  );
+
+  testWidgets(
+    'calls onError when error occurs',
+    (tester) async {
+      final error = Exception();
+      final stream = Stream<int>.error(error);
+
+      late Object receivedError;
+
+      await tester.pumpWidget(
+        HookBuilder(builder: (context) {
+          useStreamSubscription<int>(
+            stream,
+            onError: (error, stackTrace) {
+              receivedError = error;
+            },
+          );
+          return const SizedBox();
+        }),
+      );
+
+      expect(receivedError, same(error));
+    },
+  );
+
+  testWidgets(
+    'calls onDone when stream is closed',
+    (tester) async {
+      final streamController = StreamController<int>.broadcast();
+
+      var onDoneCalled = false;
+
+      await tester.pumpWidget(
+        HookBuilder(builder: (context) {
+          useStreamSubscription<int>(
+            streamController.stream,
+            onDone: () {
+              onDoneCalled = true;
+            },
+          );
+          return const SizedBox();
+        }),
+      );
+
+      await streamController.close();
+
+      expect(onDoneCalled, isTrue);
+    },
+  );
+
+  testWidgets(
+    'cancels subscription when cancelOnError is true and error occurrs',
+    (tester) async {
+      // ignore: close_sinks
+      final streamController = StreamController<int>();
+
+      await tester.pumpWidget(
+        HookBuilder(builder: (context) {
+          useStreamSubscription<int>(
+            streamController.stream,
+            // onError needs to be set to prevent unhandled errors from propagating.
+            onError: (error, stackTrace) {},
+            cancelOnError: true,
+          );
+          return const SizedBox();
+        }),
+      );
+
+      expect(streamController.hasListener, isTrue);
+
+      streamController.addError(Exception());
+
+      await tester.pump();
+
+      expect(streamController.hasListener, isFalse);
+    },
+  );
+
+  testWidgets(
+    'listens new stream when stream is changed',
+    (tester) async {
+      const value1 = 42;
+      const value2 = 43;
+
+      final stream1 = Stream<int>.value(value1);
+      final stream2 = Stream<int>.value(value2);
+
+      late int receivedValue;
+
+      await tester.pumpWidget(
+        HookBuilder(
+          key: const Key('hook_builder'),
+          builder: (context) {
+            useStreamSubscription<int>(
+              stream1,
+              onData: (data) => receivedValue = data,
+            );
+            return const SizedBox();
+          },
+        ),
+      );
+
+      expect(receivedValue, value1);
+
+      // Listens to the stream2
+      await tester.pumpWidget(
+        HookBuilder(
+          key: const Key('hook_builder'),
+          builder: (context) {
+            useStreamSubscription<int>(
+              stream2,
+              onData: (data) => receivedValue = data,
+            );
+            return const SizedBox();
+          },
+        ),
+      );
+
+      expect(receivedValue, value2);
+    },
+  );
+
+  testWidgets(
+    'stop listening when cancel is called on StreamSubscription',
+    (tester) async {
+      final controller = StreamController<int>();
+      late StreamSubscription<int> subscription;
+
+      const value1 = 42;
+
+      var receivedValue = 0;
+
+      await tester.pumpWidget(
+        HookBuilder(
+          key: const Key('hook_builder'),
+          builder: (context) {
+            subscription = useStreamSubscription<int>(
+              controller.stream,
+              onData: (data) => receivedValue = data,
+            );
+            return const SizedBox();
+          },
+        ),
+      );
+
+      // Awaiting on subscription.cancel never ends.
+      // Needs to be checked if this is expected.
+      unawaited(subscription.cancel());
+
+      controller.add(value1);
+
+      await tester.pump();
+
+      expect(receivedValue, isZero);
+
+      unawaited(controller.close());
+    },
+  );
+}


### PR DESCRIPTION
Adds a new hook `useStreamSubscription` that allows you to subscribe to a Stream and register callback handlers such as `onData`, `onError`, and `onDone`.

Returns the `StreamSubscription` returned by the `Stream.listen`.


**CAUTION**
Awaiting on the returned `StreamSubscription.cancel` never ends on a test. Not sure if this is somehow expected.

https://github.com/jezsung/flutter_hooks/blob/53ed52bf3605952f2eb790d8c57b2831684b2479/packages/flutter_hooks/test/use_stream_subscription_test.dart#L207-L209

