### PR TITLE
Mimic React Hook's dependencies comparison

### DIFF
--- a/packages/flutter_hooks/lib/src/framework.dart
+++ b/packages/flutter_hooks/lib/src/framework.dart
@@ -172,7 +172,23 @@ Calling them outside of build method leads to an unstable state and is therefore
       if (!i1.moveNext() || !i2.moveNext()) {
         return true;
       }
-      if (i1.current != i2.current) {
+
+      final curr1 = i1.current;
+      final curr2 = i2.current;
+
+      if (curr1 is num && curr2 is num) {
+        // Checks if both are NaN
+        if (curr1.isNaN && curr2.isNaN) {
+          return true;
+        }
+
+        // Checks if one is 0.0 and the other is -0.0
+        if (curr1 == 0 && curr2 == 0) {
+          return curr1.isNegative == curr2.isNegative;
+        }
+      }
+
+      if (curr1 != curr2) {
         return false;
       }
     }

--- a/packages/flutter_hooks/test/use_effect_test.dart
+++ b/packages/flutter_hooks/test/use_effect_test.dart
@@ -249,6 +249,55 @@ void main() {
     verifyNoMoreInteractions(disposerA);
     verifyNoMoreInteractions(effect);
   });
+
+  testWidgets(
+      'does NOT call effect when one of keys is NaN and others are same',
+      (tester) async {
+    parameters = [double.nan];
+    await tester.pumpWidget(builder());
+
+    verifyInOrder([
+      effect(),
+      unrelated(),
+    ]);
+    verifyNoMoreInteractions(effect);
+
+    parameters = [double.nan];
+    await tester.pumpWidget(builder());
+
+    verifyNoMoreInteractions(effect);
+  });
+
+  testWidgets(
+      'calls effect when one of keys is changed from 0.0 to -0.0 and vice versa',
+      (tester) async {
+    parameters = [0.0];
+    await tester.pumpWidget(builder());
+
+    verifyInOrder([
+      effect(),
+      unrelated(),
+    ]);
+    verifyNoMoreInteractions(effect);
+
+    parameters = [-0.0];
+    await tester.pumpWidget(builder());
+
+    verifyInOrder([
+      effect(),
+      unrelated(),
+    ]);
+    verifyNoMoreInteractions(effect);
+
+    parameters = [0.0];
+    await tester.pumpWidget(builder());
+
+    verifyInOrder([
+      effect(),
+      unrelated(),
+    ]);
+    verifyNoMoreInteractions(effect);
+  });
 }
 
 class MockEffect extends Mock {


### PR DESCRIPTION
[#155 ](https://github.com/rrousselGit/flutter_hooks/issues/155#issuecomment-1641688259)

This PR changes the comparison behavior to mimic the React Hook dependencies comparison which uses [`Object.is()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/is).

Previously, `keys` are compared by the `==` operator. The Dart `==` operator works differently from the JavaScript `Object.is()`:

Object.is()
```js
Object.is(NaN, NaN) // true
Object.is(0, -0) // false
```
Dart ==
```dart
double.nan == double.nan // false
0 == -0 // true
```

This PR checks if a list of `keys` contain a value with the type `num` and proceeds to handle cases where the value is either `NaN` or `0.0` and `-0.0`.