### PR TITLE
Feature: ability to use nullable listener in useListenableSelector

### DIFF
--- a/packages/flutter_hooks/lib/src/listenable_selector.dart
+++ b/packages/flutter_hooks/lib/src/listenable_selector.dart
@@ -25,7 +25,7 @@ part of 'hooks.dart';
 ///
 
 R useListenableSelector<R>(
-  Listenable listenable,
+  Listenable? listenable,
   R Function() selector,
 ) {
   return use(_ListenableSelectorHook(listenable, selector));
@@ -34,7 +34,7 @@ R useListenableSelector<R>(
 class _ListenableSelectorHook<R> extends Hook<R> {
   const _ListenableSelectorHook(this.listenable, this.selector);
 
-  final Listenable listenable;
+  final Listenable? listenable;
   final R Function() selector;
 
   @override
@@ -49,7 +49,7 @@ class _ListenableSelectorHookState<R>
   @override
   void initHook() {
     super.initHook();
-    hook.listenable.addListener(_listener);
+    hook.listenable?.addListener(_listener);
   }
 
   @override
@@ -63,8 +63,8 @@ class _ListenableSelectorHookState<R>
     }
 
     if (hook.listenable != oldHook.listenable) {
-      oldHook.listenable.removeListener(_listener);
-      hook.listenable.addListener(_listener);
+      oldHook.listenable?.removeListener(_listener);
+      hook.listenable?.addListener(_listener);
       _selectorResult = hook.selector();
     }
   }
@@ -83,7 +83,7 @@ class _ListenableSelectorHookState<R>
 
   @override
   void dispose() {
-    hook.listenable.removeListener(_listener);
+    hook.listenable?.removeListener(_listener);
   }
 
   @override

--- a/packages/flutter_hooks/test/use_listenable_selector_test.dart
+++ b/packages/flutter_hooks/test/use_listenable_selector_test.dart
@@ -106,7 +106,7 @@ void main() {
 
           return Container();
         },
-      )
+      ),
     );
 
     expect(result, notFoundValue);

--- a/packages/flutter_hooks/test/use_listenable_selector_test.dart
+++ b/packages/flutter_hooks/test/use_listenable_selector_test.dart
@@ -85,6 +85,38 @@ void main() {
     listenable.dispose();
   });
 
+  testWidgets('null as Listener', (tester) async {
+    const notFoundValue = -1;
+    final testListener = ValueNotifier(false);
+    final listenable = ValueNotifier(777);
+    var result = 0;
+
+    await tester.pumpWidget(
+      HookBuilder(
+        builder: (context) {
+          final shouldUseListener = useListenableSelector(testListener, () {
+            return testListener.value;
+          });
+
+          final actualListener = shouldUseListener ? listenable : null;
+
+          result = useListenableSelector(actualListener, () {
+            return actualListener?.value ?? notFoundValue;
+          });
+
+          return Container();
+        },
+      )
+    );
+
+    expect(result, notFoundValue);
+    testListener.value = true;
+
+    await tester.pump();
+
+    expect(result, listenable.value);
+  });
+
   testWidgets('update selector', (tester) async {
     final listenable = ValueNotifier(0);
     var isOdd = false;


### PR DESCRIPTION
## Description

This Pull Request adds the ability to pass `null` as a parameter to the `useListenableSelector` hook. Previously, you could only pass a `Listener` instance, but now you can also pass `Listener?` to the function.

This change is necessary when the listener is initialized later, for example, on the second render. By allowing `null` as a parameter, developers can delay the initialization of the listener until it's ready.

## Example Usage

```dart
// Before
useListenableSelector<SomeListener>(myListener, () => myListener.data);

// After
useListenableSelector<SomeListener?>(null, () => myListener?.data);
