### PR TITLE
Clarify the use of useFuture

### DIFF
--- a/packages/flutter_hooks/lib/src/async.dart
+++ b/packages/flutter_hooks/lib/src/async.dart
@@ -5,6 +5,20 @@ part of 'hooks.dart';
 /// * [preserveState] determines if the current value should be preserved when changing
 /// the [Future] instance.
 ///
+/// The [Future] needs to be created outside of [useFuture].
+/// If the [Future] is created inside [useFuture], then, every time the build
+/// method gets called, the [Future] will be called again. One way to create
+/// the [Future] outside of [useFuture] is by using [useMemoized].
+///
+/// ```dart
+/// // BAD
+/// useFuture(fetchFromDatabase());
+///
+/// // GOOD
+/// final result = useMemoized(() => fetchFromDatabase());
+/// useFuture(result);
+/// ```
+///
 /// See also:
 ///   * [Future], the listened object.
 ///   * [useStream], similar to [useFuture] but for [Stream].


### PR DESCRIPTION
**Describe what scenario you think is uncovered by the existing examples/articles**
Document that Futures should not be created inside `useFuture` (see #132 & #119)

**Describe why existing examples/articles do not cover this case**
`useFuture` behaves like `FutureBuilder`. This is not explicitly stated but rather implied through an understanding of Flutter Hooks. This understanding may not be intuitive for new users and can lead to a misunderstanding about the behavior of `useFuture`.
