### PR TITLE
Upgrade to Flutter 3.7.0 and Dart 2.19

### DIFF
--- a/packages/flutter_hooks/CHANGELOG.md
+++ b/packages/flutter_hooks/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.21.0 - unreleased
+
+- Upgrade Flutter to 3.7.0 and Dart 2.19.0 (thanks to @Reprevise)
+
 ## 0.20.4 - 2023-12-29
 
 - Added `useDebounced` (thanks to @itisnajim)
@@ -134,7 +138,7 @@ Migrated flutter_hooks to null-safety (special thanks to @DevNico for the help!)
 
 **Breaking change**:
 
-- Removed `HookState.didBuild`.  
+- Removed `HookState.didBuild`.
   If you still need it, use `addPostFrameCallback` or `Future.microtask`.
 
 **Non-breaking changes**:

--- a/packages/flutter_hooks/pubspec.yaml
+++ b/packages/flutter_hooks/pubspec.yaml
@@ -6,8 +6,8 @@ issue_tracker: https://github.com/rrousselGit/flutter_hooks/issues
 version: 0.20.4
 
 environment:
-  sdk: ">=2.17.0 <3.0.0"
-  flutter: ">=3.0.0"
+  sdk: ">=2.19.0 <3.0.0"
+  flutter: ">=3.7.0"
 
 dependencies:
   flutter:


### PR DESCRIPTION
Prerequisite to deprecate the `useIsMounted` hook which will be done in a separate PR so this is kept clean to resolve any issues there are during upgrading. I updated the changelog as well, and all tests are passing.