### PR TITLE
Adds check for either WidgetStates or MaterialStates in useMaterialStatesController debug test

### DIFF
--- a/packages/flutter_hooks/CHANGELOG.md
+++ b/packages/flutter_hooks/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.20.6 - 2024-03-18
+
+- Updates `useMaterialStatesController` test to pass before and after `MaterialState` is migrated to `WidgetState` in Flutter
+
 ## 0.20.5 - 2024-02-05
 
 - Deprecate the `useIsMounted` hook as you should use `BuildContext.mounted` instead if you're on Flutter 3.7.0 or greater

--- a/packages/flutter_hooks/test/use_material_states_controller_test.dart
+++ b/packages/flutter_hooks/test/use_material_states_controller_test.dart
@@ -21,10 +21,17 @@ void main() {
       element
           .toDiagnosticsNode(style: DiagnosticsTreeStyle.offstage)
           .toStringDeep(),
-      equalsIgnoringHashCodes(
-        'HookBuilder\n'
-        ' │ useMaterialStatesController: MaterialStatesController#00000({})\n'
-        ' └SizedBox(renderObject: RenderConstrainedBox#00000)\n',
+      anyOf(
+        equalsIgnoringHashCodes(
+          'HookBuilder\n'
+          ' │ useMaterialStatesController: MaterialStatesController#00000({})\n'
+          ' └SizedBox(renderObject: RenderConstrainedBox#00000)\n',
+        ),
+        equalsIgnoringHashCodes(
+          'HookBuilder\n'
+          ' │ useMaterialStatesController: WidgetStatesController#00000({})\n'
+          ' └SizedBox(renderObject: RenderConstrainedBox#00000)\n',
+        )
       ),
     );
   });

--- a/packages/flutter_hooks/test/use_material_states_controller_test.dart
+++ b/packages/flutter_hooks/test/use_material_states_controller_test.dart
@@ -22,17 +22,16 @@ void main() {
           .toDiagnosticsNode(style: DiagnosticsTreeStyle.offstage)
           .toStringDeep(),
       anyOf(
-        equalsIgnoringHashCodes(
-          'HookBuilder\n'
-          ' │ useMaterialStatesController: MaterialStatesController#00000({})\n'
-          ' └SizedBox(renderObject: RenderConstrainedBox#00000)\n',
-        ),
-        equalsIgnoringHashCodes(
-          'HookBuilder\n'
-          ' │ useMaterialStatesController: WidgetStatesController#00000({})\n'
-          ' └SizedBox(renderObject: RenderConstrainedBox#00000)\n',
-        )
-      ),
+          equalsIgnoringHashCodes(
+            'HookBuilder\n'
+            ' │ useMaterialStatesController: MaterialStatesController#00000({})\n'
+            ' └SizedBox(renderObject: RenderConstrainedBox#00000)\n',
+          ),
+          equalsIgnoringHashCodes(
+            'HookBuilder\n'
+            ' │ useMaterialStatesController: WidgetStatesController#00000({})\n'
+            ' └SizedBox(renderObject: RenderConstrainedBox#00000)\n',
+          )),
     );
   });
 


### PR DESCRIPTION
Flutter is moving MaterialState, and it's related functions outside of the Material library and changing it's name to WidgetState. MaterialState will still be available as is, just marked deprecated, and made a typedef of WidgetState. However this causes MaterialState debug functions to return with strings mentioning "WidgetState", and is a breaking change for packages using those functions. The [PR that will add that change to Flutter is here](https://github.com/flutter/flutter/pull/142151), and the [original issue is here](https://github.com/flutter/flutter/issues/138270).

Internal testing found this caused a breakage in this package, so this PR updates the test for `useMaterialStatesController` to pass both before and after that change is landed.