### PR TITLE
Modernize README code snippets

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,17 +19,16 @@ logic of say `initState` or `dispose`. An obvious example is `AnimationControlle
 
 ```dart
 class Example extends StatefulWidget {
-  final Duration duration;
+  const Example({super.key, required this.duration});
 
-  const Example({Key? key, required this.duration})
-      : super(key: key);
+  final Duration duration;
 
   @override
   _ExampleState createState() => _ExampleState();
 }
 
 class _ExampleState extends State<Example> with SingleTickerProviderStateMixin {
-  AnimationController? _controller;
+  late final AnimationController _controller;
 
   @override
   void initState() {
@@ -41,13 +40,13 @@ class _ExampleState extends State<Example> with SingleTickerProviderStateMixin {
   void didUpdateWidget(Example oldWidget) {
     super.didUpdateWidget(oldWidget);
     if (widget.duration != oldWidget.duration) {
-      _controller!.duration = widget.duration;
+      _controller.duration = widget.duration;
     }
   }
 
   @override
   void dispose() {
-    _controller!.dispose();
+    _controller.dispose();
     super.dispose();
   }
 
@@ -74,8 +73,7 @@ This library proposes a third solution:
 
 ```dart
 class Example extends HookWidget {
-  const Example({Key? key, required this.duration})
-      : super(key: key);
+  const Example({super.key, required this.duration});
 
   final Duration duration;
 

--- a/packages/flutter_hooks/resources/translations/ko_kr/README.md
+++ b/packages/flutter_hooks/resources/translations/ko_kr/README.md
@@ -17,17 +17,16 @@
 
 ```dart
 class Example extends StatefulWidget {
-  final Duration duration;
+  const Example({super.key, required this.duration});
 
-  const Example({Key? key, required this.duration})
-      : super(key: key);
+  final Duration duration;
 
   @override
   _ExampleState createState() => _ExampleState();
 }
 
 class _ExampleState extends State<Example> with SingleTickerProviderStateMixin {
-  AnimationController? _controller;
+  late final AnimationController _controller;
 
   @override
   void initState() {
@@ -39,13 +38,13 @@ class _ExampleState extends State<Example> with SingleTickerProviderStateMixin {
   void didUpdateWidget(Example oldWidget) {
     super.didUpdateWidget(oldWidget);
     if (widget.duration != oldWidget.duration) {
-      _controller!.duration = widget.duration;
+      _controller.duration = widget.duration;
     }
   }
 
   @override
   void dispose() {
-    _controller!.dispose();
+    _controller.dispose();
     super.dispose();
   }
 
@@ -70,8 +69,7 @@ Dart Mixins 으로 이 문제를 해결할 수 있지만, 다른 문제점들이
 
 ```dart
 class Example extends HookWidget {
-  const Example({Key? key, required this.duration})
-      : super(key: key);
+  const Example({super.key, required this.duration});
 
   final Duration duration;
 

--- a/packages/flutter_hooks/resources/translations/pt_br/README.md
+++ b/packages/flutter_hooks/resources/translations/pt_br/README.md
@@ -19,18 +19,16 @@ por exemplo de um `initState` ou `dispose`. Um exemplo é o `AnimationController
 
 ```dart
 class Example extends StatefulWidget {
-  final Duration duration;
+  const Example({super.key, required this.duration});
 
-  const Example({Key? key, @required this.duration})
-      : assert(duration != null),
-        super(key: key);
+  final Duration duration;
 
   @override
   _ExampleState createState() => _ExampleState();
 }
 
 class _ExampleState extends State<Example> with SingleTickerProviderStateMixin {
-  AnimationController _controller;
+  late final AnimationController _controller;
 
   @override
   void initState() {
@@ -76,9 +74,7 @@ Essa biblioteca propõe uma terceira solução:
 
 ```dart
 class Example extends HookWidget {
-  const Example({Key? key, @required this.duration})
-      : assert(duration != null),
-        super(key: key);
+  const Example({super.key, required this.duration});
 
   final Duration duration;
 

--- a/packages/flutter_hooks/resources/translations/zh_cn/README.md
+++ b/packages/flutter_hooks/resources/translations/zh_cn/README.md
@@ -20,17 +20,16 @@
 
 ```dart
 class Example extends StatefulWidget {
-  final Duration duration;
+  const Example({super.key, required this.duration});
 
-  const Example({Key? key, required this.duration})
-      : super(key: key);
+  final Duration duration;
 
   @override
   _ExampleState createState() => _ExampleState();
 }
 
 class _ExampleState extends State<Example> with SingleTickerProviderStateMixin {
-  AnimationController? _controller;
+  late final AnimationController _controller;
 
   @override
   void initState() {
@@ -42,13 +41,13 @@ class _ExampleState extends State<Example> with SingleTickerProviderStateMixin {
   void didUpdateWidget(Example oldWidget) {
     super.didUpdateWidget(oldWidget);
     if (widget.duration != oldWidget.duration) {
-      _controller!.duration = widget.duration;
+      _controller.duration = widget.duration;
     }
   }
 
   @override
   void dispose() {
-    _controller!.dispose();
+    _controller.dispose();
     super.dispose();
   }
 


### PR DESCRIPTION
This pull request adds null safety/super parameters to the README files.

Now, the first `HookWidget` example is just 11 lines of code! 🙂

```dart
class Example extends HookWidget {
  const Example({super.key, required this.duration});

  final Duration duration;

  @override
  Widget build(BuildContext context) {
    final controller = useAnimationController(duration: duration);
    return Container();
  }
}
```

I believe this PR is test-exempt since it's just a README update; let me know if I should add anything to CHANGELOG.md as well.