### PR TITLE
Add `useOnListenableChange`

### DIFF
--- a/README.md
+++ b/README.md
@@ -331,6 +331,7 @@ They will take care of creating/updating/disposing an object.
 | [useListenableSelector](https://pub.dev/documentation/flutter_hooks/latest/flutter_hooks/useListenableSelector.html) | Similar to `useListenable`, but allows filtering UI rebuilds                                        |
 | [useValueNotifier](https://pub.dev/documentation/flutter_hooks/latest/flutter_hooks/useValueNotifier.html)           | Creates a `ValueNotifier` which will be automatically disposed.                                     |
 | [useValueListenable](https://pub.dev/documentation/flutter_hooks/latest/flutter_hooks/useValueListenable.html)       | Subscribes to a `ValueListenable` and return its value.                                             |
+| [useOnListenableChange](https://pub.dev/documentation/flutter_hooks/latest/flutter_hooks/useOnListenableChange.html) | Adds a given listener callback to a `Listenable` which will be automatically removed.               |
 
 #### Misc hooks:
 

--- a/packages/flutter_hooks/CHANGELOG.md
+++ b/packages/flutter_hooks/CHANGELOG.md
@@ -1,3 +1,6 @@
+## Unreleased patch
+- Added `useOnListenableChange` (thanks to @whynotmake-it)
+
 ## 0.21.1-pre.2 - 2024-07-22
 
 - Added `onAttach` and `onDetach` to `useScrollController` and `usePageController` (thanks to @whynotmake-it)

--- a/packages/flutter_hooks/lib/src/listenable.dart
+++ b/packages/flutter_hooks/lib/src/listenable.dart
@@ -151,9 +151,8 @@ void useOnListenableChange(
 class _OnListenableChangeHook extends Hook<void> {
   const _OnListenableChangeHook(
     this.listenable,
-    this.listener, {
-    super.keys,
-  });
+    this.listener,
+  );
 
   final Listenable? listenable;
   final VoidCallback listener;

--- a/packages/flutter_hooks/lib/src/listenable.dart
+++ b/packages/flutter_hooks/lib/src/listenable.dart
@@ -165,16 +165,15 @@ class _OnListenableChangeHookState
   @override
   void initHook() {
     super.initHook();
-    hook.listenable?.addListener(hook.listener);
+    hook.listenable?.addListener(_listener);
   }
 
   @override
   void didUpdateHook(_OnListenableChangeHook oldHook) {
     super.didUpdateHook(oldHook);
-    if (hook.listenable != oldHook.listenable ||
-        oldHook.listener != hook.listener) {
-      oldHook.listenable?.removeListener(oldHook.listener);
-      hook.listenable?.addListener(hook.listener);
+    if (hook.listenable != oldHook.listenable) {
+      oldHook.listenable?.removeListener(_listener);
+      hook.listenable?.addListener(_listener);
     }
   }
 
@@ -184,6 +183,11 @@ class _OnListenableChangeHookState
   @override
   void dispose() {
     hook.listenable?.removeListener(hook.listener);
+  }
+
+  /// Wraps `hook.listener` so we have a non-changing reference to it.
+  void _listener() {
+    hook.listener();
   }
 
   @override

--- a/packages/flutter_hooks/lib/src/listenable.dart
+++ b/packages/flutter_hooks/lib/src/listenable.dart
@@ -142,10 +142,9 @@ class _UseValueNotifierHookState<T>
 ///  * [useListenable]
 void useOnListenableChange(
   Listenable? listenable,
-  VoidCallback listener, {
-  List<Object?>? keys,
-}) {
-  return use(_OnListenableChangeHook(listenable, listener, keys: keys));
+  VoidCallback listener,
+) {
+  return use(_OnListenableChangeHook(listenable, listener));
 }
 
 class _OnListenableChangeHook extends Hook<void> {
@@ -172,7 +171,8 @@ class _OnListenableChangeHookState
   @override
   void didUpdateHook(_OnListenableChangeHook oldHook) {
     super.didUpdateHook(oldHook);
-    if (hook.listenable != oldHook.listenable) {
+    if (hook.listenable != oldHook.listenable ||
+        oldHook.listener != hook.listener) {
       oldHook.listenable?.removeListener(oldHook.listener);
       hook.listenable?.addListener(hook.listener);
     }

--- a/packages/flutter_hooks/lib/src/listenable.dart
+++ b/packages/flutter_hooks/lib/src/listenable.dart
@@ -128,3 +128,68 @@ class _UseValueNotifierHookState<T>
   @override
   String get debugLabel => 'useValueNotifier';
 }
+
+/// Adds a given [listener] to a [Listenable] and removes it when the hook is
+/// disposed.
+///
+/// As opposed to `useListenable`, this hook does not mark the widget as needing
+/// build when the listener is called. Use this for side effects that do not
+/// require a rebuild.
+///
+/// See also:
+///  * [Listenable]
+///  * [ValueListenable]
+///  * [useListenable]
+void useOnListenableChange<T extends Listenable>(
+  T? listenable,
+  VoidCallback listener, {
+  List<Object?>? keys,
+}) {
+  return use(_OnListenableChangeHook(listenable, listener, keys: keys));
+}
+
+class _OnListenableChangeHook extends Hook<void> {
+  const _OnListenableChangeHook(
+    this.listenable,
+    this.listener, {
+    super.keys,
+  });
+
+  final Listenable? listenable;
+  final VoidCallback listener;
+
+  @override
+  _OnListenableChangeHookState createState() => _OnListenableChangeHookState();
+}
+
+class _OnListenableChangeHookState
+    extends HookState<void, _OnListenableChangeHook> {
+  @override
+  void initHook() {
+    super.initHook();
+    hook.listenable?.addListener(hook.listener);
+  }
+
+  @override
+  void didUpdateHook(_OnListenableChangeHook oldHook) {
+    super.didUpdateHook(oldHook);
+    if (hook.listenable != oldHook.listenable) {
+      oldHook.listenable?.removeListener(oldHook.listener);
+      hook.listenable?.addListener(hook.listener);
+    }
+  }
+
+  @override
+  void build(BuildContext context) {}
+
+  @override
+  void dispose() {
+    hook.listenable?.removeListener(hook.listener);
+  }
+
+  @override
+  String get debugLabel => 'useOnListenableChange';
+
+  @override
+  Object? get debugValue => hook.listenable;
+}

--- a/packages/flutter_hooks/lib/src/listenable.dart
+++ b/packages/flutter_hooks/lib/src/listenable.dart
@@ -182,7 +182,7 @@ class _OnListenableChangeHookState
 
   @override
   void dispose() {
-    hook.listenable?.removeListener(hook.listener);
+    hook.listenable?.removeListener(_listener);
   }
 
   /// Wraps `hook.listener` so we have a non-changing reference to it.

--- a/packages/flutter_hooks/lib/src/listenable.dart
+++ b/packages/flutter_hooks/lib/src/listenable.dart
@@ -140,8 +140,8 @@ class _UseValueNotifierHookState<T>
 ///  * [Listenable]
 ///  * [ValueListenable]
 ///  * [useListenable]
-void useOnListenableChange<T extends Listenable>(
-  T? listenable,
+void useOnListenableChange(
+  Listenable? listenable,
   VoidCallback listener, {
   List<Object?>? keys,
 }) {

--- a/packages/flutter_hooks/test/use_on_listenable_change_test.dart
+++ b/packages/flutter_hooks/test/use_on_listenable_change_test.dart
@@ -99,7 +99,7 @@ void main() {
 
     await tester.pumpWidget(
       HookBuilder(builder: (context) {
-        useOnListenableChange<ValueNotifier<int>>(null, () {});
+        useOnListenableChange(null, () {});
         return const SizedBox();
       }),
     );

--- a/packages/flutter_hooks/test/use_on_listenable_change_test.dart
+++ b/packages/flutter_hooks/test/use_on_listenable_change_test.dart
@@ -1,3 +1,5 @@
+import 'dart:math';
+
 import 'package:flutter/foundation.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
@@ -81,6 +83,46 @@ void main() {
       expect(listenable1.hasListeners, isFalse);
       // ignore: invalid_use_of_protected_member
       expect(listenable2.hasListeners, isTrue);
+    }),
+  );
+
+  testWidgets(
+    'listens new listener when listener is changed',
+    (tester) => tester.runAsync(() async {
+      final listenable = ValueNotifier(42);
+      late final int value;
+
+      void listener1() {
+        throw StateError('listener1 should not have been called');
+      }
+
+      void listener2() {
+        value = listenable.value;
+      }
+
+      await tester.pumpWidget(
+        HookBuilder(
+          key: const Key('hook_builder'),
+          builder: (context) {
+            useOnListenableChange(listenable, listener1);
+            return const SizedBox();
+          },
+        ),
+      );
+
+      await tester.pumpWidget(
+        HookBuilder(
+          key: const Key('hook_builder'),
+          builder: (context) {
+            useOnListenableChange(listenable, listener2);
+            return const SizedBox();
+          },
+        ),
+      );
+
+      listenable.value++;
+      // By now, we should have subscribed to listener2, which sets the value
+      expect(value, 43);
     }),
   );
 

--- a/packages/flutter_hooks/test/use_on_listenable_change_test.dart
+++ b/packages/flutter_hooks/test/use_on_listenable_change_test.dart
@@ -53,13 +53,12 @@ void main() {
 
   testWidgets(
     'listens new Listenable when Listenable is changed',
-    (tester) => tester.runAsync(() async {
+    (tester) async {
       final listenable1 = ValueNotifier(42);
       final listenable2 = ValueNotifier(42);
 
       await tester.pumpWidget(
         HookBuilder(
-          key: const Key('hook_builder'),
           builder: (context) {
             useOnListenableChange(listenable1, () {});
             return const SizedBox();
@@ -69,7 +68,6 @@ void main() {
 
       await tester.pumpWidget(
         HookBuilder(
-          key: const Key('hook_builder'),
           builder: (context) {
             useOnListenableChange(listenable2, () {});
             return const SizedBox();
@@ -81,12 +79,12 @@ void main() {
       expect(listenable1.hasListeners, isFalse);
       // ignore: invalid_use_of_protected_member
       expect(listenable2.hasListeners, isTrue);
-    }),
+    },
   );
 
   testWidgets(
     'listens new listener when listener is changed',
-    (tester) => tester.runAsync(() async {
+    (tester) async {
       final listenable = ValueNotifier(42);
       late final int value;
 
@@ -100,7 +98,6 @@ void main() {
 
       await tester.pumpWidget(
         HookBuilder(
-          key: const Key('hook_builder'),
           builder: (context) {
             useOnListenableChange(listenable, listener1);
             return const SizedBox();
@@ -110,7 +107,6 @@ void main() {
 
       await tester.pumpWidget(
         HookBuilder(
-          key: const Key('hook_builder'),
           builder: (context) {
             useOnListenableChange(listenable, listener2);
             return const SizedBox();
@@ -121,7 +117,7 @@ void main() {
       listenable.value++;
       // By now, we should have subscribed to listener2, which sets the value
       expect(value, 43);
-    }),
+    },
   );
 
   testWidgets('unsubscribes when listenable becomes null', (tester) async {
@@ -161,9 +157,7 @@ void main() {
     // ignore: invalid_use_of_protected_member
     expect(listenable.hasListeners, isTrue);
 
-    await tester.pumpWidget(
-      Container(),
-    );
+    await tester.pumpWidget(Container());
 
     // ignore: invalid_use_of_protected_member
     expect(listenable.hasListeners, isFalse);

--- a/packages/flutter_hooks/test/use_on_listenable_change_test.dart
+++ b/packages/flutter_hooks/test/use_on_listenable_change_test.dart
@@ -1,5 +1,3 @@
-import 'dart:math';
-
 import 'package:flutter/foundation.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';

--- a/packages/flutter_hooks/test/use_on_listenable_change_test.dart
+++ b/packages/flutter_hooks/test/use_on_listenable_change_test.dart
@@ -1,0 +1,110 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
+
+import 'mock.dart';
+
+void main() {
+  testWidgets('debugFillProperties', (tester) async {
+    final listenable = ValueNotifier(42);
+
+    await tester.pumpWidget(
+      HookBuilder(builder: (context) {
+        useOnListenableChange(listenable, () {});
+        return const SizedBox();
+      }),
+    );
+
+    await tester.pump();
+
+    final element = tester.element(find.byType(HookBuilder));
+
+    expect(
+      element
+          .toDiagnosticsNode(style: DiagnosticsTreeStyle.offstage)
+          .toStringDeep(),
+      equalsIgnoringHashCodes(
+        'HookBuilder\n'
+        ' │ useOnListenableChange: ValueNotifier<int>#00000(42)\n'
+        ' └SizedBox(renderObject: RenderConstrainedBox#00000)\n',
+      ),
+    );
+  });
+
+  testWidgets('calls listener when Listenable updates', (tester) async {
+    final listenable = ValueNotifier(42);
+
+    int? value;
+
+    await tester.pumpWidget(
+      HookBuilder(builder: (context) {
+        useOnListenableChange(
+          listenable,
+          () => value = listenable.value,
+        );
+        return const SizedBox();
+      }),
+    );
+
+    expect(value, isNull);
+    listenable.value++;
+    expect(value, 43);
+  });
+
+  testWidgets(
+    'listens new Listenable when Listenable is changed',
+    (tester) => tester.runAsync(() async {
+      final listenable1 = ValueNotifier(42);
+      final listenable2 = ValueNotifier(42);
+
+      await tester.pumpWidget(
+        HookBuilder(
+          key: const Key('hook_builder'),
+          builder: (context) {
+            useOnListenableChange(listenable1, () {});
+            return const SizedBox();
+          },
+        ),
+      );
+
+      await tester.pumpWidget(
+        HookBuilder(
+          key: const Key('hook_builder'),
+          builder: (context) {
+            useOnListenableChange(listenable2, () {});
+            return const SizedBox();
+          },
+        ),
+      );
+
+      // ignore: invalid_use_of_protected_member
+      expect(listenable1.hasListeners, isFalse);
+      // ignore: invalid_use_of_protected_member
+      expect(listenable2.hasListeners, isTrue);
+    }),
+  );
+
+  testWidgets('unsubscribes when listenable becomes null', (tester) async {
+    final listenable = ValueNotifier(42);
+
+    await tester.pumpWidget(
+      HookBuilder(builder: (context) {
+        useOnListenableChange(listenable, () {});
+        return const SizedBox();
+      }),
+    );
+
+    // ignore: invalid_use_of_protected_member
+    expect(listenable.hasListeners, isTrue);
+
+    await tester.pumpWidget(
+      HookBuilder(builder: (context) {
+        useOnListenableChange<ValueNotifier<int>>(null, () {});
+        return const SizedBox();
+      }),
+    );
+
+    // ignore: invalid_use_of_protected_member
+    expect(listenable.hasListeners, isFalse);
+  });
+}

--- a/packages/flutter_hooks/test/use_on_listenable_change_test.dart
+++ b/packages/flutter_hooks/test/use_on_listenable_change_test.dart
@@ -147,4 +147,25 @@ void main() {
     // ignore: invalid_use_of_protected_member
     expect(listenable.hasListeners, isFalse);
   });
+
+  testWidgets('unsubscribes when disposed', (tester) async {
+    final listenable = ValueNotifier(42);
+
+    await tester.pumpWidget(
+      HookBuilder(builder: (context) {
+        useOnListenableChange(listenable, () {});
+        return const SizedBox();
+      }),
+    );
+
+    // ignore: invalid_use_of_protected_member
+    expect(listenable.hasListeners, isTrue);
+
+    await tester.pumpWidget(
+      Container(),
+    );
+
+    // ignore: invalid_use_of_protected_member
+    expect(listenable.hasListeners, isFalse);
+  });
 }


### PR DESCRIPTION
Fixes #326
(potentially, people can just call `.value` for `ValueListenables`, so I would argue an extra hook isn't needed
Fixes #389