### PR TITLE
feat: Add `useCarouselController`

### DIFF
--- a/README.md
+++ b/README.md
@@ -358,6 +358,7 @@ A series of hooks with no particular theme.
 | [useExpansionTileController](https://api.flutter.dev/flutter/material/ExpansionTileController-class.html)                            | Creates a `ExpansionTileController`.                                                                                        |
 | [useDebounced](https://pub.dev/documentation/flutter_hooks/latest/flutter_hooks/useDebounced.html)                                   | Returns a debounced version of the provided value, triggering widget updates accordingly after a specified timeout duration |
 | [useDraggableScrollableController](https://api.flutter.dev/flutter/widgets/DraggableScrollableController-class.html)                 | Creates a `DraggableScrollableController`.                                                                                  |
+| [useCarouselController](https://pub.dev/documentation/flutter_hooks/latest/flutter_hooks/useCarouselController.html)                     | Creates and disposes a `CarouselController`.                                                                                  |
 
 ## Contributions
 

--- a/packages/flutter_hooks/lib/src/carousel_controller.dart
+++ b/packages/flutter_hooks/lib/src/carousel_controller.dart
@@ -1,0 +1,46 @@
+part of 'hooks.dart';
+
+/// Creates a [CarouselController] that will be disposed automatically.
+///
+/// See also:
+/// - [CarouselController]
+CarouselController useCarouselController({
+  int initialItem = 0,
+  List<Object?>? keys,
+}) {
+  return use(
+    _CarouselControllerHook(
+      initialItem: initialItem,
+      keys: keys,
+    ),
+  );
+}
+
+class _CarouselControllerHook extends Hook<CarouselController> {
+  const _CarouselControllerHook({
+    required this.initialItem,
+    super.keys,
+  });
+
+  final int initialItem;
+
+  @override
+  HookState<CarouselController, Hook<CarouselController>> createState() =>
+      _CarouselControllerHookState();
+}
+
+class _CarouselControllerHookState
+    extends HookState<CarouselController, _CarouselControllerHook> {
+  late final controller = CarouselController(
+    initialItem: hook.initialItem,
+  );
+
+  @override
+  CarouselController build(BuildContext context) => controller;
+
+  @override
+  void dispose() => controller.dispose();
+
+  @override
+  String get debugLabel => 'useCarouselController';
+}

--- a/packages/flutter_hooks/lib/src/hooks.dart
+++ b/packages/flutter_hooks/lib/src/hooks.dart
@@ -4,6 +4,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart'
     show
         Brightness,
+        CarouselController,
         DraggableScrollableController,
         ExpansionTileController,
         WidgetStatesController,
@@ -17,6 +18,7 @@ import 'framework.dart';
 
 part 'animation.dart';
 part 'async.dart';
+part 'carousel_controller.dart';
 part 'draggable_scrollable_controller.dart';
 part 'expansion_tile_controller.dart';
 part 'fixed_extent_scroll_controller.dart';

--- a/packages/flutter_hooks/test/carousel_controller_test.dart
+++ b/packages/flutter_hooks/test/carousel_controller_test.dart
@@ -49,7 +49,8 @@ void main() {
       expect(controller.onDetach, controller2.onDetach);
     });
 
-    testWidgets("returns a CarouselController that doesn't change", (tester) async {
+    testWidgets("returns a CarouselController that doesn't change",
+        (tester) async {
       late CarouselController controller;
       late CarouselController controller2;
 
@@ -72,7 +73,8 @@ void main() {
       expect(identical(controller, controller2), isTrue);
     });
 
-    testWidgets('passes hook parameters to the CarouselController', (tester) async {
+    testWidgets('passes hook parameters to the CarouselController',
+        (tester) async {
       late CarouselController controller;
 
       await tester.pumpWidget(

--- a/packages/flutter_hooks/test/carousel_controller_test.dart
+++ b/packages/flutter_hooks/test/carousel_controller_test.dart
@@ -1,0 +1,115 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_hooks/src/framework.dart';
+import 'package:flutter_hooks/src/hooks.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'mock.dart';
+
+void main() {
+  testWidgets('debugFillProperties', (tester) async {
+    await tester.pumpWidget(
+      HookBuilder(builder: (context) {
+        useCarouselController();
+        return const SizedBox();
+      }),
+    );
+
+    final element = tester.element(find.byType(HookBuilder));
+
+    expect(
+      element
+          .toDiagnosticsNode(style: DiagnosticsTreeStyle.offstage)
+          .toStringDeep(),
+      equalsIgnoringHashCodes(
+        'HookBuilder\n'
+        ' │ useCarouselController: CarouselController#00000(no clients)\n'
+        ' └SizedBox(renderObject: RenderConstrainedBox#00000)\n',
+      ),
+    );
+  });
+
+  group('useCarouselController', () {
+    testWidgets('initial values matches with real constructor', (tester) async {
+      late CarouselController controller;
+      late CarouselController controller2;
+
+      await tester.pumpWidget(
+        HookBuilder(builder: (context) {
+          controller2 = CarouselController();
+          controller = useCarouselController();
+          return Container();
+        }),
+      );
+
+      expect(controller.initialItem, controller2.initialItem);
+      expect(controller.initialScrollOffset, controller2.initialScrollOffset);
+      expect(controller.keepScrollOffset, controller2.keepScrollOffset);
+      expect(controller.onAttach, controller2.onAttach);
+      expect(controller.onDetach, controller2.onDetach);
+    });
+
+    testWidgets("returns a CarouselController that doesn't change", (tester) async {
+      late CarouselController controller;
+      late CarouselController controller2;
+
+      await tester.pumpWidget(
+        HookBuilder(builder: (context) {
+          controller = useCarouselController();
+          return Container();
+        }),
+      );
+
+      expect(controller, isA<CarouselController>());
+
+      await tester.pumpWidget(
+        HookBuilder(builder: (context) {
+          controller2 = useCarouselController();
+          return Container();
+        }),
+      );
+
+      expect(identical(controller, controller2), isTrue);
+    });
+
+    testWidgets('passes hook parameters to the CarouselController', (tester) async {
+      late CarouselController controller;
+
+      await tester.pumpWidget(
+        HookBuilder(
+          builder: (context) {
+            controller = useCarouselController(
+              initialItem: 42,
+            );
+
+            return Container();
+          },
+        ),
+      );
+
+      expect(controller.initialItem, 42);
+    });
+
+    testWidgets('disposes the CarouselController on unmount', (tester) async {
+      late CarouselController controller;
+
+      await tester.pumpWidget(
+        HookBuilder(
+          builder: (context) {
+            controller = useCarouselController();
+            return Container();
+          },
+        ),
+      );
+
+      // pump another widget so that the old one gets disposed
+      await tester.pumpWidget(Container());
+
+      expect(
+        () => controller.addListener(() {}),
+        throwsA(isFlutterError.having(
+            (e) => e.message, 'message', contains('disposed'))),
+      );
+    });
+  });
+}


### PR DESCRIPTION
Thanks for the great package!

I have added CarouselController hooks for use with CarouselView, now available in Flutter 3.24 (stable)!

Implementation and testing was based on usePageController and useSearchController.

Please let me know if anything is missing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced README documentation for better clarity on Flutter Hooks, including examples and rules for using hooks.
	- Introduced `useCarouselController` hook for managing carousel functionality, simplifying state management.

- **Bug Fixes**
	- Improved documentation on hot-reload behavior and custom hook creation.

- **Tests**
	- Added comprehensive tests for the `useCarouselController` hook, validating its functionality and resource management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->