### PR TITLE
Add weak property to useState

### DIFF
--- a/packages/flutter_hooks/test/use_state_test.dart
+++ b/packages/flutter_hooks/test/use_state_test.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
 
+import 'memoized_test.dart';
 import 'mock.dart';
 
 void main() {
@@ -31,6 +32,90 @@ void main() {
 
     expect(state.value, 43);
     expect(element.dirty, false);
+
+    // dispose
+    await tester.pumpWidget(const SizedBox());
+
+    expect(() => state.addListener(() {}), throwsFlutterError);
+  });
+
+  testWidgets('useState value not change when initial updates', (tester) async {
+    late ValueNotifier<int> state;
+    late HookElement element;
+
+    await tester.pumpWidget(HookBuilder(
+      builder: (context) {
+        element = context as HookElement;
+        state = useState(42);
+        return MaterialApp(home: Text('${state.value}'));
+      },
+    ));
+
+    expect(state.value, 42);
+    expect(element.dirty, false);
+    expect(find.text('42'), findsOneWidget);
+
+    await tester.pump();
+
+    expect(state.value, 42);
+    expect(element.dirty, false);
+    expect(find.text('42'), findsOneWidget);
+
+    await tester.pumpWidget(HookBuilder(
+      builder: (context) {
+        element = context as HookElement;
+        state = useState(43);
+        return MaterialApp(home: Text('${state.value}'));
+      },
+    ));
+
+    expect(state.value, 42);
+    expect(element.dirty, false);
+    expect(find.text('42'), findsOneWidget);
+
+    await tester.pump();
+
+    expect(state.value, 42);
+    expect(element.dirty, false);
+    expect(find.text('42'), findsOneWidget);
+
+    // dispose
+    await tester.pumpWidget(const SizedBox());
+
+    expect(() => state.addListener(() {}), throwsFlutterError);
+  });
+
+  testWidgets('useState(weak true) updates', (tester) async {
+    late ValueNotifier<int> state;
+    late HookElement element;
+
+    await tester.pumpWidget(HookBuilder(
+      builder: (context) {
+        element = context as HookElement;
+        state = useState(42, weak: true);
+        return MaterialApp(home: Text('${state.value}'));
+      },
+    ));
+
+    await tester.pump();
+
+    expect(state.value, 42);
+    expect(element.dirty, false);
+    expect(find.text('42'), findsOneWidget);
+
+    await tester.pumpWidget(HookBuilder(
+      builder: (context) {
+        element = context as HookElement;
+        state = useState(43, weak: true);
+        return MaterialApp(home: Text('${state.value}'));
+      },
+    ));
+    
+    await tester.pump();
+
+    expect(state.value, 43);
+    expect(element.dirty, false);
+    expect(find.text('43'), findsOneWidget);
 
     // dispose
     await tester.pumpWidget(const SizedBox());


### PR DESCRIPTION
I missed a function that can easily update value in `useState` when initial data changes, without using additional hooks like `useEffect` or `onValueChanged`. It is very common in Flutter when using widgets.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced `useState` hook with a new `weak` parameter
	- Added more flexible state management control in Flutter hooks
	- Introduced ability to conditionally update state across widget rebuilds

- **Tests**
	- Added comprehensive test cases for new `useState` hook behavior
	- Verified state update scenarios with weak and standard state management

<!-- end of auto-generated comment: release notes by coderabbit.ai -->