### PR TITLE
Run test suite on flutter stable channel too

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,6 +17,7 @@ jobs:
           - flutter_hooks
         channel:
           - master
+          - stable
 
     steps:
       - uses: actions/checkout@v2
@@ -30,11 +31,12 @@ jobs:
 
       - name: Check format
         run: dart format --set-exit-if-changed .
-        if: matrix.channel == 'master'
+        if: matrix.channel == 'stable'
         working-directory: packages/${{ matrix.package }}
 
       - name: Analyze
         run: dart analyze .
+        if: matrix.channel == 'stable'
         working-directory: packages/${{ matrix.package }}
 
       - name: Run tests

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,6 +18,7 @@ jobs:
         channel:
           - master
           - stable
+      fail-fast: false
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,4 +45,5 @@ jobs:
 
       - name: Upload coverage to codecov
         run: curl -s https://codecov.io/bash | bash
+        if: matrix.channel == 'stable'
         working-directory: packages/${{ matrix.package }}


### PR DESCRIPTION
I saw that tests on #464 were failing because of a change on flutter master channel. This turns on testing for the stable channel too, so that's easier to see if tests are failing because of a future change that cannot be adressed in code right now, or if they'd be failing in production too

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a "stable" release channel for our build process, allowing the system to prioritize quality checks for stable releases and improve overall targeting of enhancements.
- **Chores**
  - Refined workflow execution so that all tasks run to completion, even if some processes fail, resulting in more comprehensive build feedback and enhanced system reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->