### PR TITLE
set minimum flutter version to 3.27.0 and dart 3.6

### DIFF
--- a/packages/flutter_hooks/pubspec.yaml
+++ b/packages/flutter_hooks/pubspec.yaml
@@ -6,8 +6,8 @@ issue_tracker: https://github.com/rrousselGit/flutter_hooks/issues
 version: 0.21.2
 
 environment:
-  sdk: ">=2.17.0 <3.0.0"
-  flutter: ">=3.21.0-13.0.pre.4"
+  sdk: ">=3.6.0 <4.0.0"
+  flutter: ">=3.27.0"
 
 dependencies:
   flutter:


### PR DESCRIPTION
Hey!
i just ran into an issue in another repo action: https://github.com/maplibre/flutter-maplibre-gl/actions/runs/14990160700

Which says CarouselController not found. did some small debugging and found out that the Carousel-Widget was added in flutter 3.27 so i updated the minimum flutter and dart version. 

edit: sorry, this was the correct action: https://github.com/maplibre/flutter-maplibre-gl/actions/runs/14990160700

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated minimum required versions for Dart and Flutter SDKs to ensure compatibility with newer releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->