### PR TITLE
feat: add  `useThrottled` hooks.

### DIFF
--- a/packages/flutter_hooks/lib/src/hooks.dart
+++ b/packages/flutter_hooks/lib/src/hooks.dart
@@ -37,6 +37,7 @@ part 'scroll_controller.dart';
 part 'search_controller.dart';
 part 'tab_controller.dart';
 part 'text_controller.dart';
+part 'throttled.dart';
 part 'transformation_controller.dart';
 part 'tree_sliver_controller.dart';
 part 'widget_states_controller.dart';

--- a/packages/flutter_hooks/lib/src/throttled.dart
+++ b/packages/flutter_hooks/lib/src/throttled.dart
@@ -1,0 +1,42 @@
+part of 'hooks.dart';
+
+/// widget ignore updates accordingly after a specified [duration] duration.
+///
+/// Example:
+/// ```dart
+/// String userInput = ''; // Your input value
+///
+/// // Create a throttle callback
+/// final throttle = useThrottle(duration: const Duration(milliseconds: 500));
+/// // Assume a fetch method fetchData(String query) exists
+/// Button(onPressed: () => throttle(() => fetchData(userInput)));
+/// ```
+void Function(VoidCallback callback) useThrottle({
+  Duration duration = const Duration(milliseconds: 500),
+}) {
+  final throttler = useMemoized(() => _Throttler(duration), [duration]);
+  return throttler.run;
+}
+
+class _Throttler {
+  _Throttler(this.duration)
+      : assert(
+          0 < duration.inMilliseconds,
+          'duration must be greater than 0ms',
+        );
+
+  final Duration duration;
+
+  Timer? _timer;
+
+  bool get _isRunning => _timer != null;
+
+  void run(VoidCallback callback) {
+    if (!_isRunning) {
+      _timer = Timer(duration, () {
+        _timer = null;
+      });
+      callback();
+    }
+  }
+}

--- a/packages/flutter_hooks/lib/src/throttled.dart
+++ b/packages/flutter_hooks/lib/src/throttled.dart
@@ -7,23 +7,19 @@ part of 'hooks.dart';
 /// String userInput = ''; // Your input value
 ///
 /// // Create a throttle callback
-/// final throttle = useThrottle(duration: const Duration(milliseconds: 500));
+/// final throttle = useThrottled(duration: const Duration(milliseconds: 500));
 /// // Assume a fetch method fetchData(String query) exists
 /// Button(onPressed: () => throttle(() => fetchData(userInput)));
 /// ```
-void Function(VoidCallback callback) useThrottle({
-  Duration duration = const Duration(milliseconds: 500),
+void Function(VoidCallback callback) useThrottled({
+  required Duration duration,
 }) {
   final throttler = useMemoized(() => _Throttler(duration), [duration]);
   return throttler.run;
 }
 
 class _Throttler {
-  _Throttler(this.duration)
-      : assert(
-          0 < duration.inMilliseconds,
-          'duration must be greater than 0ms',
-        );
+  _Throttler(this.duration);
 
   final Duration duration;
 

--- a/packages/flutter_hooks/test/use_throttle_test.dart
+++ b/packages/flutter_hooks/test/use_throttle_test.dart
@@ -3,10 +3,10 @@ import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
-  group('useThrottle', () {
+  group('useThrottled', () {
     testWidgets('no update when tapping multiple times', (tester) async {
       await tester.runAsync<void>(() async {
-        await tester.pumpWidget(const _UseThrottleTestWidget());
+        await tester.pumpWidget(const _UseThrottledTestWidget());
 
         final text = find.byType(GestureDetector);
         expect(find.text('1'), findsOneWidget);
@@ -32,7 +32,7 @@ void main() {
 
     testWidgets('update number after duration', (tester) async {
       await tester.runAsync<void>(() async {
-        await tester.pumpWidget(const _UseThrottleTestWidget());
+        await tester.pumpWidget(const _UseThrottledTestWidget());
 
         final text = find.byType(GestureDetector);
         expect(find.text('1'), findsOneWidget);
@@ -49,13 +49,13 @@ void main() {
   });
 }
 
-class _UseThrottleTestWidget extends HookWidget {
-  const _UseThrottleTestWidget();
+class _UseThrottledTestWidget extends HookWidget {
+  const _UseThrottledTestWidget();
 
   @override
   Widget build(BuildContext context) {
     final textNumber = useState(1);
-    final throttle = useThrottle();
+    final throttle = useThrottled(duration: _duration);
 
     void updateText() {
       textNumber.value++;

--- a/packages/flutter_hooks/test/use_throttle_test.dart
+++ b/packages/flutter_hooks/test/use_throttle_test.dart
@@ -1,0 +1,73 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('useThrottle', () {
+    testWidgets('no update when tapping multiple times', (tester) async {
+      await tester.runAsync<void>(() async {
+        await tester.pumpWidget(const _UseThrottleTestWidget());
+
+        final text = find.byType(GestureDetector);
+        expect(find.text('1'), findsOneWidget);
+
+        await tester.tap(text);
+        await tester.pump();
+
+        expect(find.text('2'), findsOneWidget);
+
+        await tester.tap(text);
+        await tester.pump();
+        expect(find.text('2'), findsOneWidget);
+
+        await tester.tap(text);
+        await tester.pump();
+        expect(find.text('2'), findsOneWidget);
+
+        await tester.tap(text);
+        await tester.pump();
+        expect(find.text('2'), findsOneWidget);
+      });
+    });
+
+    testWidgets('update number after duration', (tester) async {
+      await tester.runAsync<void>(() async {
+        await tester.pumpWidget(const _UseThrottleTestWidget());
+
+        final text = find.byType(GestureDetector);
+        expect(find.text('1'), findsOneWidget);
+
+        await tester.pumpAndSettle(_duration);
+        await Future<void>.delayed(_duration);
+
+        await tester.tap(text);
+        await tester.pump();
+
+        expect(find.text('2'), findsOneWidget);
+      });
+    });
+  });
+}
+
+class _UseThrottleTestWidget extends HookWidget {
+  const _UseThrottleTestWidget();
+
+  @override
+  Widget build(BuildContext context) {
+    final textNumber = useState(1);
+    final throttle = useThrottle();
+
+    void updateText() {
+      textNumber.value++;
+    }
+
+    return MaterialApp(
+      home: GestureDetector(
+        onTap: () => throttle(updateText),
+        child: Text(textNumber.value.toString()),
+      ),
+    );
+  }
+}
+
+const _duration = Duration(milliseconds: 500);


### PR DESCRIPTION
close. #472

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Introduced a new hook that allows throttling the execution of callbacks, helping to limit how frequently a callback can be triggered within a specified duration.

- **Tests**
  - Added tests to verify that the new throttling hook correctly limits callback execution and behaves as expected during rapid user interactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->