### PR TITLE
Add useCupertinoTabController hook for automatic disposal of CupertinoTabController

### DIFF
--- a/packages/flutter_hooks/lib/src/cupertino_tab_controller.dart
+++ b/packages/flutter_hooks/lib/src/cupertino_tab_controller.dart
@@ -1,0 +1,47 @@
+part of 'hooks.dart';
+
+
+/// Creates a [CupertinoTabController] that will be disposed automatically.
+///
+/// See also:
+/// - [CupertinoTabController]
+CupertinoTabController useCupertinoTabController({
+  int initialIndex = 0,
+  List<Object?>? keys,
+}) {
+  return use(
+    _CupertinoTabControllerHook(
+      initialIndex: initialIndex,
+      keys: keys,
+    ),
+  );
+}
+
+class _CupertinoTabControllerHook extends Hook<CupertinoTabController> {
+  const _CupertinoTabControllerHook({
+    required this.initialIndex,
+    super.keys,
+  });
+
+  final int initialIndex;
+
+  @override
+  HookState<CupertinoTabController, Hook<CupertinoTabController>> createState() =>
+      _CupertinoTabControllerHookState();
+}
+
+class _CupertinoTabControllerHookState
+    extends HookState<CupertinoTabController, _CupertinoTabControllerHook> {
+  late final controller = CupertinoTabController(
+    initialIndex: hook.initialIndex,
+  );
+
+  @override
+  CupertinoTabController build(BuildContext context) => controller;
+
+  @override
+  void dispose() => controller.dispose();
+
+  @override
+  String get debugLabel => 'useCupertinoTabController';
+}

--- a/packages/flutter_hooks/lib/src/hooks.dart
+++ b/packages/flutter_hooks/lib/src/hooks.dart
@@ -1,5 +1,7 @@
 import 'dart:async';
 
+import 'package:flutter/cupertino.dart'
+    show CupertinoTabController;
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart'
     show
@@ -21,6 +23,7 @@ import 'framework.dart';
 part 'animation.dart';
 part 'async.dart';
 part 'carousel_controller.dart';
+part 'cupertino_tab_controller.dart';
 part 'debounced.dart';
 part 'draggable_scrollable_controller.dart';
 part 'expansion_tile_controller.dart';

--- a/packages/flutter_hooks/test/use_cupertino_tab_controller_test.dart
+++ b/packages/flutter_hooks/test/use_cupertino_tab_controller_test.dart
@@ -1,0 +1,89 @@
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter_hooks/src/framework.dart';
+import 'package:flutter_hooks/src/hooks.dart';
+
+import 'mock.dart';
+
+void main() {
+  testWidgets('debugFillProperties', (tester) async {
+    await tester.pumpWidget(
+      HookBuilder(builder: (context) {
+        useCupertinoTabController();
+        return const SizedBox();
+      }),
+    );
+
+    await tester.pump();
+
+    final element = tester.element(find.byType(HookBuilder));
+
+    expect(
+      element
+          .toDiagnosticsNode(style: DiagnosticsTreeStyle.offstage)
+          .toStringDeep(),
+      equalsIgnoringHashCodes(
+        'HookBuilder\n'
+        " │ useCupertinoTabController: Instance of 'CupertinoTabController'\n"
+        ' └SizedBox(renderObject: RenderConstrainedBox#00000)\n',
+      ),
+    );
+  });
+
+  group('useCupertinoCupertinoCupertinoTabController', () {
+    testWidgets('initial values matches with real constructor', (tester) async {
+      late CupertinoTabController controller;
+      late CupertinoTabController controller2;
+
+      await tester.pumpWidget(
+        HookBuilder(builder: (context) {
+          controller2 = CupertinoTabController();
+          controller = useCupertinoTabController();
+          return Container();
+        }),
+      );
+
+      expect(controller.index, controller2.index);
+    });
+    testWidgets("returns a CupertinoTabController that doesn't change",
+        (tester) async {
+      late CupertinoTabController controller;
+      late CupertinoTabController controller2;
+
+      await tester.pumpWidget(
+        HookBuilder(builder: (context) {
+          controller = useCupertinoTabController(initialIndex: 1);
+          return Container();
+        }),
+      );
+
+      expect(controller, isA<CupertinoTabController>());
+
+      await tester.pumpWidget(
+        HookBuilder(builder: (context) {
+          controller2 = useCupertinoTabController(initialIndex: 1);
+          return Container();
+        }),
+      );
+
+      expect(identical(controller, controller2), isTrue);
+    });
+
+    testWidgets('passes hook parameters to the CupertinoTabController',
+        (tester) async {
+      late CupertinoTabController controller;
+
+      await tester.pumpWidget(
+        HookBuilder(
+          builder: (context) {
+            controller = useCupertinoTabController(initialIndex: 2);
+
+            return Container();
+          },
+        ),
+      );
+
+      expect(controller.index, 2);
+    });
+  });
+}


### PR DESCRIPTION
Hi Remi 👋

Resolves #222

Introduce a new hook for managing the lifecycle of CupertinoTabController, ensuring it disposes automatically. Include tests to verify its functionality and correct behavior.

no towel required. 🪐