### PR TITLE
feat: add descendantsAreTraversable parameter to useFocusNode

### DIFF
--- a/packages/flutter_hooks/lib/src/focus_node.dart
+++ b/packages/flutter_hooks/lib/src/focus_node.dart
@@ -10,6 +10,7 @@ FocusNode useFocusNode({
   bool skipTraversal = false,
   bool canRequestFocus = true,
   bool descendantsAreFocusable = true,
+  bool descendantsAreTraversable = true,
 }) {
   return use(
     _FocusNodeHook(
@@ -18,6 +19,7 @@ FocusNode useFocusNode({
       skipTraversal: skipTraversal,
       canRequestFocus: canRequestFocus,
       descendantsAreFocusable: descendantsAreFocusable,
+      descendantsAreTraversable: descendantsAreTraversable,
     ),
   );
 }
@@ -29,6 +31,7 @@ class _FocusNodeHook extends Hook<FocusNode> {
     required this.skipTraversal,
     required this.canRequestFocus,
     required this.descendantsAreFocusable,
+    required this.descendantsAreTraversable,
   });
 
   final String? debugLabel;
@@ -36,6 +39,7 @@ class _FocusNodeHook extends Hook<FocusNode> {
   final bool skipTraversal;
   final bool canRequestFocus;
   final bool descendantsAreFocusable;
+  final bool descendantsAreTraversable;
 
   @override
   _FocusNodeHookState createState() {
@@ -50,6 +54,7 @@ class _FocusNodeHookState extends HookState<FocusNode, _FocusNodeHook> {
     skipTraversal: hook.skipTraversal,
     canRequestFocus: hook.canRequestFocus,
     descendantsAreFocusable: hook.descendantsAreFocusable,
+    descendantsAreTraversable: hook.descendantsAreTraversable,
   );
 
   @override
@@ -59,6 +64,7 @@ class _FocusNodeHookState extends HookState<FocusNode, _FocusNodeHook> {
       ..skipTraversal = hook.skipTraversal
       ..canRequestFocus = hook.canRequestFocus
       ..descendantsAreFocusable = hook.descendantsAreFocusable
+      ..descendantsAreTraversable = hook.descendantsAreTraversable
       ..onKeyEvent = hook.onKeyEvent;
   }
 

--- a/packages/flutter_hooks/test/use_focus_node_test.dart
+++ b/packages/flutter_hooks/test/use_focus_node_test.dart
@@ -76,6 +76,8 @@ void main() {
     expect(focusNode.skipTraversal, official.skipTraversal);
     expect(focusNode.canRequestFocus, official.canRequestFocus);
     expect(focusNode.descendantsAreFocusable, official.descendantsAreFocusable);
+    expect(focusNode.descendantsAreTraversable,
+        official.descendantsAreTraversable);
   });
 
   testWidgets('has all the FocusNode parameters', (tester) async {
@@ -91,6 +93,7 @@ void main() {
           skipTraversal: true,
           canRequestFocus: false,
           descendantsAreFocusable: false,
+          descendantsAreTraversable: false,
         );
         return Container();
       }),
@@ -101,6 +104,7 @@ void main() {
     expect(focusNode.skipTraversal, true);
     expect(focusNode.canRequestFocus, false);
     expect(focusNode.descendantsAreFocusable, false);
+    expect(focusNode.descendantsAreTraversable, false);
   });
 
   testWidgets('handles parameter change', (tester) async {
@@ -118,6 +122,7 @@ void main() {
           skipTraversal: true,
           canRequestFocus: false,
           descendantsAreFocusable: false,
+          descendantsAreTraversable: false,
         );
 
         return Container();
@@ -140,5 +145,6 @@ void main() {
     expect(focusNode.skipTraversal, false);
     expect(focusNode.canRequestFocus, true);
     expect(focusNode.descendantsAreFocusable, true);
+    expect(focusNode.descendantsAreTraversable, true);
   });
 }


### PR DESCRIPTION
## Summary
Adds support for the `descendantsAreTraversable` parameter to `useFocusNode` hook to match Flutter's `FocusNode` constructor.

## Context
Flutter added the `descendantsAreTraversable` parameter to `FocusNode` to control whether descendants of this focus node can be traversed by the focus system. This parameter was missing from the `useFocusNode` hook, preventing users from accessing this functionality through flutter_hooks.

## Changes
- [x] Added `descendantsAreTraversable` parameter to `useFocusNode` function with default value `true`
- [x] Updated `_FocusNodeHook` class to handle the new parameter
- [x] Modified `_FocusNodeHookState` to properly initialize and update the parameter
- [x] Added updated tests for the new parameter

## Testing
- All existing tests continue to pass (218 tests total)
- Update tests to verify default value matches Flutter's `FocusNode`
- Update tests to verify parameter is properly passed to `FocusNode` constructor
- Update tests to verify parameter updates work correctly when hook rebuilds
- Code passes all linting rules

## Backward Compatibility
**Fully backward compatible** - existing code will continue to work unchanged as the new parameter has a default value of `true` matching Flutter's behavior.

## References
- [FocusNode.descendantsAreTraversable documentation](https://api.flutter.dev/flutter/widgets/FocusNode/descendantsAreTraversable.html)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configuring the traversability of descendants in the focus node hook with a new parameter.
* **Tests**
  * Updated tests to verify correct handling of the new descendants traversability option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->