### PR TITLE
fix(useExpansibleController): add dispose

### DIFF
--- a/packages/flutter_hooks/lib/src/expansion_tile_controller.dart
+++ b/packages/flutter_hooks/lib/src/expansion_tile_controller.dart
@@ -27,11 +27,17 @@ class _ExpansibleControllerHook extends Hook<ExpansibleController> {
 
 class _ExpansibleControllerHookState
     extends HookState<ExpansibleController, _ExpansibleControllerHook> {
-  final controller = ExpansibleController();
+  final _controller = ExpansibleController();
 
   @override
   String get debugLabel => 'useExpansibleController';
 
   @override
-  ExpansibleController build(BuildContext context) => controller;
+  ExpansibleController build(BuildContext context) => _controller;
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
 }

--- a/packages/flutter_hooks/test/use_expansible_controller_test.dart
+++ b/packages/flutter_hooks/test/use_expansible_controller_test.dart
@@ -78,5 +78,33 @@ void main() {
       controller.collapse();
       expect(controller.isExpanded, false);
     });
+
+    testWidgets('check ExpansibleController gets disposed', (tester) async {
+      late ExpansibleController controller;
+      await tester.pumpWidget(MaterialApp(
+        home: Scaffold(
+          body: HookBuilder(builder: (context) {
+            controller = useExpansibleController();
+            return ExpansionTile(
+              controller: controller,
+              title: const Text('Expansion Tile'),
+            );
+          }),
+        ),
+      ));
+
+      await tester.pumpWidget(const SizedBox());
+
+      expect(
+        () => controller.addListener(() {}),
+        throwsA(
+          isFlutterError.having(
+            (e) => e.message,
+            'message',
+            contains('disposed'),
+          ),
+        ),
+      );
+    });
   });
 }


### PR DESCRIPTION
The `useExpansibleController` hook wasn't disposing the `ExpansibleController`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved resource cleanup and disposal handling for expansion tile controllers to prevent memory leaks.

* **Tests**
  * Added test coverage for controller disposal behavior to ensure proper lifecycle management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->