### PR TITLE
Add useMultiTickerProvider Hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -320,6 +320,7 @@ They will take care of creating/updating/disposing an object.
 | Name                                                                                                                     | Description                                                            |
 | ------------------------------------------------------------------------------------------------------------------------ | ---------------------------------------------------------------------- |
 | [useSingleTickerProvider](https://pub.dev/documentation/flutter_hooks/latest/flutter_hooks/useSingleTickerProvider.html) | Creates a single usage `TickerProvider`.                               |
+| [useMultiTickerProvider](https://pub.dev/documentation/flutter_hooks/latest/flutter_hooks/useMultiTickerProvider.html)  | Creates a `TickerProvider` that supports creating multiple `Ticker`s. |
 | [useAnimationController](https://pub.dev/documentation/flutter_hooks/latest/flutter_hooks/useAnimationController.html)   | Creates an `AnimationController` which will be automatically disposed. |
 | [useAnimation](https://pub.dev/documentation/flutter_hooks/latest/flutter_hooks/useAnimation.html)                       | Subscribes to an `Animation` and returns its value.                    |
 

--- a/packages/flutter_hooks/lib/src/animation.dart
+++ b/packages/flutter_hooks/lib/src/animation.dart
@@ -267,8 +267,8 @@ class _MultiTickerProviderHookState
   Ticker createTicker(TickerCallback onTick) {
     final ticker = Ticker(onTick, debugLabel: 'created by $context (multi)');
     _updateTickerModeNotifier();
-    _updateTickers();
     _tickers.add(ticker);
+    _updateTickers();
     return ticker;
   }
 

--- a/packages/flutter_hooks/lib/src/animation.dart
+++ b/packages/flutter_hooks/lib/src/animation.dart
@@ -241,7 +241,7 @@ class _TickerProviderHookState
 /// Creates a multi-usage [TickerProvider].
 ///
 /// See also:
-///  * [SingleTickerProviderStateMixin]
+///  * [TickerProviderStateMixin]
 TickerProvider useMultiTickerProvider({List<Object?>? keys}) {
   return use(
     keys != null

--- a/packages/flutter_hooks/resources/translations/ja_jp/README.md
+++ b/packages/flutter_hooks/resources/translations/ja_jp/README.md
@@ -304,6 +304,7 @@ Flutter_Hooksには、再利用可能なフックのリストが既に含まれ�
 | 名前                                                                                                                     | 説明                                                                 |
 | ------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------- |
 | [useSingleTickerProvider](https://pub.dev/documentation/flutter_hooks/latest/flutter_hooks/useSingleTickerProvider.html) | 単一使用の`TickerProvider`を作成します。                            |
+| [useMultiTickerProvider](https://pub.dev/documentation/flutter_hooks/latest/flutter_hooks/useMultiTickerProvider.html)  | 複数の`Ticker`を作成できる`TickerProvider`を作成します。             |
 | [useAnimationController](https://pub.dev/documentation/flutter_hooks/latest/flutter_hooks/useAnimationController.html)   | 自動的に破棄される`AnimationController`を作成します。               |
 | [useAnimation](https://pub.dev/documentation/flutter_hooks/latest/flutter_hooks/useAnimation.html)                       | `Animation`を購読し、その値を返します。                              |
 

--- a/packages/flutter_hooks/resources/translations/ko_kr/README.md
+++ b/packages/flutter_hooks/resources/translations/ko_kr/README.md
@@ -302,6 +302,7 @@ Flutter_Hooks 는 이미 재사용 가능한 훅 목록을 제공합니다. 이 
 | Name                                                                                                                              | Description                                                |
 | --------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------- |
 | [useSingleTickerProvider](https://pub.dartlang.org/documentation/flutter_hooks/latest/flutter_hooks/useSingleTickerProvider.html) | `TickerProvider`를 생성합니다.                             |
+| [useMultiTickerProvider](https://pub.dev/documentation/flutter_hooks/latest/flutter_hooks/useMultiTickerProvider.html)  | 여러 `Ticker`를 생성할 수 있는 `TickerProvider`를 생성합니다. |
 | [useAnimationController](https://pub.dartlang.org/documentation/flutter_hooks/latest/flutter_hooks/useAnimationController.html)   | 자동으로 dispose 되는 `AnimationController`를 생성합니다.  |
 | [useAnimation](https://pub.dartlang.org/documentation/flutter_hooks/latest/flutter_hooks/useAnimation.html)                       | `Animation` 를 구독합니다. 해당 객체의 value를 반환합니다. |
 

--- a/packages/flutter_hooks/resources/translations/pt_br/README.md
+++ b/packages/flutter_hooks/resources/translations/pt_br/README.md
@@ -322,6 +322,7 @@ Eles serão responsáveis por criar/atualizar/descartar o objeto.
 | nome                                                                                                                              | descrição                                                 |
 | --------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------- |
 | [useSingleTickerProvider](https://pub.dartlang.org/documentation/flutter_hooks/latest/flutter_hooks/useSingleTickerProvider.html) | Cria um único `TickerProvider`.                           |
+| [useMultiTickerProvider](https://pub.dev/documentation/flutter_hooks/latest/flutter_hooks/useMultiTickerProvider.html)  | Cria um `TickerProvider` que suporta criar múltiplos `Ticker`s. |
 | [useAnimationController](https://pub.dartlang.org/documentation/flutter_hooks/latest/flutter_hooks/useAnimationController.html)   | Cria um `AnimationController` automaticamente descartado. |
 | [useAnimation](https://pub.dartlang.org/documentation/flutter_hooks/latest/flutter_hooks/useAnimation.html)                       | Inscreve um uma `Animation` e retorna seu valor.          |
 

--- a/packages/flutter_hooks/resources/translations/zh_cn/README.md
+++ b/packages/flutter_hooks/resources/translations/zh_cn/README.md
@@ -313,6 +313,7 @@ Flutter_Hooks 已经包含一些不同类别的可复用的钩子：
 | 名称                                                                                                                     | 描述                                       |
 | ------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------ |
 | [useSingleTickerProvider](https://pub.dev/documentation/flutter_hooks/latest/flutter_hooks/useSingleTickerProvider.html) | 创建单次使用的 `TickerProvider`          |
+| [useMultiTickerProvider](https://pub.dev/documentation/flutter_hooks/latest/flutter_hooks/useMultiTickerProvider.html)  | 创建支持多个 `Ticker` 的 `TickerProvider` |
 | [useAnimationController](https://pub.dev/documentation/flutter_hooks/latest/flutter_hooks/useAnimationController.html)   | 创建并会自动释放的 `AnimationController` |
 | [useAnimation](https://pub.dev/documentation/flutter_hooks/latest/flutter_hooks/useAnimation.html)                       | 订阅一个 `Animation` 并返回其当前值      |
 

--- a/packages/flutter_hooks/test/use_multi_ticker_provider_test.dart
+++ b/packages/flutter_hooks/test/use_multi_ticker_provider_test.dart
@@ -103,6 +103,32 @@ void main() {
     }
   });
 
+  testWidgets('new tickers created when TickerMode disabled are muted', (tester) async {
+    late TickerProvider provider;
+
+    await tester.pumpWidget(TickerMode(
+      enabled: false,
+      child: HookBuilder(builder: (context) {
+        provider = useMultiTickerProvider();
+        return Container();
+      }),
+    ));
+
+    final animationController = AnimationController(
+      vsync: provider,
+      duration: const Duration(seconds: 1),
+    );
+
+    // Attempt to start the animation — when the underlying ticker is muted
+    // (because TickerMode is disabled), the controller should not advance.
+    unawaited(animationController.forward());
+    await tester.pump(const Duration(milliseconds: 100));
+
+    expect(animationController.value, equals(0.0));
+
+    animationController.dispose();
+  });
+
   testWidgets('useMultiTickerProvider pass down keys', (tester) async {
     late TickerProvider provider;
     List<Object?>? keys;

--- a/packages/flutter_hooks/test/use_multi_ticker_provider_test.dart
+++ b/packages/flutter_hooks/test/use_multi_ticker_provider_test.dart
@@ -20,9 +20,7 @@ void main() {
     final element = tester.element(find.byType(HookBuilder));
 
     expect(
-      element
-          .toDiagnosticsNode(style: DiagnosticsTreeStyle.offstage)
-          .toStringDeep(),
+      element.toDiagnosticsNode(style: DiagnosticsTreeStyle.offstage).toStringDeep(),
       equalsIgnoringHashCodes(
         'HookBuilder\n'
         ' │ useMultiTickerProvider\n'
@@ -46,6 +44,7 @@ void main() {
       vsync: provider,
       duration: const Duration(seconds: 1),
     );
+    // With a multi provider, creating additional AnimationControllers is allowed.
     final animationControllerB = AnimationController(
       vsync: provider,
       duration: const Duration(seconds: 1),
@@ -53,12 +52,6 @@ void main() {
 
     unawaited(animationControllerA.forward());
     unawaited(animationControllerB.forward());
-
-    // With a multi provider, creating additional AnimationControllers is allowed.
-    expect(
-      () => AnimationController(vsync: provider, duration: const Duration(seconds: 1)),
-      returnsNormally,
-    );
 
     animationControllerA.dispose();
     animationControllerB.dispose();

--- a/packages/flutter_hooks/test/use_multi_ticker_provider_test.dart
+++ b/packages/flutter_hooks/test/use_multi_ticker_provider_test.dart
@@ -1,0 +1,125 @@
+import 'dart:async';
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
+
+import 'mock.dart';
+
+void main() {
+  testWidgets('debugFillProperties', (tester) async {
+    await tester.pumpWidget(
+      HookBuilder(builder: (context) {
+        useMultiTickerProvider();
+        return const SizedBox();
+      }),
+    );
+
+    await tester.pump();
+
+    final element = tester.element(find.byType(HookBuilder));
+
+    expect(
+      element
+          .toDiagnosticsNode(style: DiagnosticsTreeStyle.offstage)
+          .toStringDeep(),
+      equalsIgnoringHashCodes(
+        'HookBuilder\n'
+        ' │ useMultiTickerProvider\n'
+        ' └SizedBox(renderObject: RenderConstrainedBox#00000)\n',
+      ),
+    );
+  });
+
+  testWidgets('useMultiTickerProvider basic', (tester) async {
+    late TickerProvider provider;
+
+    await tester.pumpWidget(TickerMode(
+      enabled: true,
+      child: HookBuilder(builder: (context) {
+        provider = useMultiTickerProvider();
+        return Container();
+      }),
+    ));
+
+    final animationControllerA = AnimationController(
+      vsync: provider,
+      duration: const Duration(seconds: 1),
+    );
+    final animationControllerB = AnimationController(
+      vsync: provider,
+      duration: const Duration(seconds: 1),
+    );
+
+    unawaited(animationControllerA.forward());
+    unawaited(animationControllerB.forward());
+
+    // With a multi provider, creating additional AnimationControllers is allowed.
+    expect(
+      () => AnimationController(vsync: provider, duration: const Duration(seconds: 1)),
+      returnsNormally,
+    );
+
+    animationControllerA.dispose();
+    animationControllerB.dispose();
+
+    await tester.pumpWidget(const SizedBox());
+  });
+
+  testWidgets('useMultiTickerProvider unused', (tester) async {
+    await tester.pumpWidget(HookBuilder(builder: (context) {
+      useMultiTickerProvider();
+      return Container();
+    }));
+
+    await tester.pumpWidget(const SizedBox());
+  });
+
+  testWidgets('useMultiTickerProvider still active', (tester) async {
+    late TickerProvider provider;
+
+    await tester.pumpWidget(TickerMode(
+      enabled: true,
+      child: HookBuilder(builder: (context) {
+        provider = useMultiTickerProvider();
+        return Container();
+      }),
+    ));
+
+    final animationController = AnimationController(
+      vsync: provider,
+      duration: const Duration(seconds: 1),
+    );
+
+    try {
+      // ignore: unawaited_futures
+      animationController.forward();
+
+      await tester.pumpWidget(const SizedBox());
+
+      expect(tester.takeException(), isFlutterError);
+    } finally {
+      animationController.dispose();
+    }
+  });
+
+  testWidgets('useMultiTickerProvider pass down keys', (tester) async {
+    late TickerProvider provider;
+    List<Object?>? keys;
+
+    await tester.pumpWidget(HookBuilder(builder: (context) {
+      provider = useMultiTickerProvider(keys: keys);
+      return Container();
+    }));
+
+    final previousProvider = provider;
+    keys = [];
+
+    await tester.pumpWidget(HookBuilder(builder: (context) {
+      provider = useMultiTickerProvider(keys: keys);
+      return Container();
+    }));
+
+    expect(previousProvider, isNot(provider));
+  });
+}


### PR DESCRIPTION
This PR introduces a new hook, `useMultiTickerProvider`, which extends `TickerProviderStateMixin` to support multiple `AnimationController` instances. This is particularly useful for libraries like `flutter_map_animations`, where an `AnimatedMapController` may create multiple animations dynamically.

### Problem
The existing `useSingleTickerProvider` hook is limited to a single `AnimationController` due to its reliance on `SingleTickerProviderStateMixin`. 
When used with `AnimatedMapController` (or similar controllers), this controller attempt to create more than one ticker resulting in the following error:
```
attempted to use a useSingleTickerProvider multiple times.
A SingleTickerProviderStateMixin can only be used as a TickerProvider once.
```
This limitation makes it impossible to use with a proper hook.

### Solution
The new `useMultiTickerProvider` hook leverages `TickerProviderStateMixin`, allowing it to provide multiple tickers for one `AnimationController` instance. This aligns on seamless experience for developers using `flutter_hooks`.

### Usage Example
```dart
final ticker = useMultiTickerProvider();
final controller = useMemoized(() => AnimatedMapController(vsync: ticker));
```

### Changes
- Added `useMultiTickerProvider` hook.
- Updated documentation to include usage examples and differences from `useSingleTickerProvider`.

### Testing
- Added unit tests to ensure the hook works as expected.
- Verified compatibility with existing `flutter_hooks` patterns.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added useMultiTickerProvider hook to provide and manage multiple tickers from a single provider.

* **Documentation**
  * Updated docs and added translations (Japanese, Korean, Portuguese, Chinese) describing the new hook.

* **Tests**
  * Added comprehensive tests covering usage, lifecycle, behavior under disabled ticker mode, keys changes, and error conditions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->