### PR TITLE
Add useEffectEvent hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,6 +294,7 @@ A set of low-level hooks that interact with the different life-cycles of a widge
 | Name                                                                                                     | Description                                                         |
 | -------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------- |
 | [useEffect](https://pub.dev/documentation/flutter_hooks/latest/flutter_hooks/useEffect.html)             | Useful for side-effects and optionally canceling them.              |
+| [useEffectEvent](https://pub.dev/documentation/flutter_hooks/latest/flutter_hooks/useEffectEvent.html)   | Extracts non-reactive logic out of `useEffect`.                     |
 | [useState](https://pub.dev/documentation/flutter_hooks/latest/flutter_hooks/useState.html)               | Creates a variable and subscribes to it.                            |
 | [useMemoized](https://pub.dev/documentation/flutter_hooks/latest/flutter_hooks/useMemoized.html)         | Caches the instance of a complex object.                            |
 | [useRef](https://pub.dev/documentation/flutter_hooks/latest/flutter_hooks/useRef.html)                   | Creates an object that contains a single mutable property.          |

--- a/packages/flutter_hooks/resources/translations/ja_jp/README.md
+++ b/packages/flutter_hooks/resources/translations/ja_jp/README.md
@@ -278,6 +278,7 @@ Flutter_Hooksには、再利用可能なフックのリストが既に含まれ�
 | 名前                                                                                                     | 説明                                                                 |
 | -------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------- |
 | [useEffect](https://pub.dev/documentation/flutter_hooks/latest/flutter_hooks/useEffect.html)             | 副作用に役立ち、オプションでそれらをキャンセルします。              |
+| [useEffectEvent](https://pub.dev/documentation/flutter_hooks/latest/flutter_hooks/useEffectEvent.html)   | `useEffect`から非リアクティブなロジックを抽出します。               |
 | [useState](https://pub.dev/documentation/flutter_hooks/latest/flutter_hooks/useState.html)               | 変数を作成し、それを購読します。                                    |
 | [useMemoized](https://pub.dev/documentation/flutter_hooks/latest/flutter_hooks/useMemoized.html)         | 複雑なオブジェクトのインスタンスをキャッシュします。                |
 | [useRef](https://pub.dev/documentation/flutter_hooks/latest/flutter_hooks/useRef.html)                   | 単一の可変プロパティを含むオブジェクトを作成します。                |

--- a/packages/flutter_hooks/resources/translations/ko_kr/README.md
+++ b/packages/flutter_hooks/resources/translations/ko_kr/README.md
@@ -277,6 +277,7 @@ Flutter_Hooks 는 이미 재사용 가능한 훅 목록을 제공합니다. 이 
 | Name                                                                                                              | Description                                                  |
 | ----------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------ |
 | [useEffect](https://pub.dartlang.org/documentation/flutter_hooks/latest/flutter_hooks/useEffect.html)             | 상태를 업데이트하거나 선택적으로 취소하기에 유용합니다.      |
+| [useEffectEvent](https://pub.dartlang.org/documentation/flutter_hooks/latest/flutter_hooks/useEffectEvent.html)   | `useEffect`에서 비반응적 로직을 추출합니다.                  |
 | [useState](https://pub.dartlang.org/documentation/flutter_hooks/latest/flutter_hooks/useState.html)               | 변수를 생성하고 구독합니다.                                  |
 | [useMemoized](https://pub.dartlang.org/documentation/flutter_hooks/latest/flutter_hooks/useMemoized.html)         | 다양한 객체의 인스턴스를 캐싱합니다.                         |
 | [useRef](https://pub.dartlang.org/documentation/flutter_hooks/latest/flutter_hooks/useRef.html)                   | 하나의 프로퍼티를 포함하는 객체를 만듭니다.                  |

--- a/packages/flutter_hooks/resources/translations/pt_br/README.md
+++ b/packages/flutter_hooks/resources/translations/pt_br/README.md
@@ -299,6 +299,7 @@ Um conjunto de hooks que interagem com diferentes ciclos de vida de um widget
 | Nome                                                                                                              | descrição                                                    |
 | ----------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------ |
 | [useEffect](https://pub.dartlang.org/documentation/flutter_hooks/latest/flutter_hooks/useEffect.html)             | Útil para side-effects e opcionalmente, cancelá-los.         |
+| [useEffectEvent](https://pub.dartlang.org/documentation/flutter_hooks/latest/flutter_hooks/useEffectEvent.html)   | Extrai lógica não reativa do `useEffect`.                    |
 | [useState](https://pub.dartlang.org/documentation/flutter_hooks/latest/flutter_hooks/useState.html)               | Cria uma variável e escuta suas mudanças.                    |
 | [useMemoized](https://pub.dartlang.org/documentation/flutter_hooks/latest/flutter_hooks/useMemoized.html)         | Guarda a instância de um objeto complexo.                    |
 | [useContext](https://pub.dartlang.org/documentation/flutter_hooks/latest/flutter_hooks/useContext.html)           | Obtém o `BuildContext` do `HookWidget`.                      |

--- a/packages/flutter_hooks/resources/translations/zh_cn/README.md
+++ b/packages/flutter_hooks/resources/translations/zh_cn/README.md
@@ -287,6 +287,7 @@ Flutter_Hooks 已经包含一些不同类别的可复用的钩子：
 | 名称                                                                                                     | 描述                                         |
 | -------------------------------------------------------------------------------------------------------- | -------------------------------------------- |
 | [useEffect](https://pub.dev/documentation/flutter_hooks/latest/flutter_hooks/useEffect.html)             | 用于处理副作用，并可选择性地进行清理       |
+| [useEffectEvent](https://pub.dev/documentation/flutter_hooks/latest/flutter_hooks/useEffectEvent.html)   | 从 `useEffect` 中提取非响应式逻辑          |
 | [useState](https://pub.dev/documentation/flutter_hooks/latest/flutter_hooks/useState.html)               | 创建一个变量并订阅它的变化                 |
 | [useMemoized](https://pub.dev/documentation/flutter_hooks/latest/flutter_hooks/useMemoized.html)         | 缓存复杂对象的实例                         |
 | [useRef](https://pub.dev/documentation/flutter_hooks/latest/flutter_hooks/useRef.html)                   | 创建一个包含单个可变属性的对象           |

--- a/packages/flutter_hooks/test/use_effect_event_test.dart
+++ b/packages/flutter_hooks/test/use_effect_event_test.dart
@@ -1,3 +1,5 @@
+// ignore_for_file: avoid_types_on_closure_parameters, avoid_positional_boolean_parameters
+
 import 'package:flutter/foundation.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
@@ -6,159 +8,88 @@ import 'mock.dart';
 
 void main() {
   group('useEffectEvent', () {
-    testWidgets('effect event should always invoke callback with latest state',
+    // These tests demonstrate WHY useEffectEvent is needed in Flutter.
+    // The problem: when an effect registers a callback with an external system,
+    // that system holds onto the callback reference. If the effect doesn't
+    // re-run, the external system has a stale callback even though fresh
+    // functions are created on each rebuild.
+    testWidgets('external system holds stale reference without useEffectEvent',
         (tester) async {
-      late void Function() event;
-      late int expectedNumber;
-      int? capturedNumber;
+      final externalSystem = _MockConnection();
+      final logs = <String>[];
 
-      Widget buildWidget() {
-        return HookBuilder(
-          builder: (context) {
-            final current = expectedNumber;
-            event = useEffectEvent(() {
-              capturedNumber = current;
-            });
-            return const SizedBox();
-          },
-        );
+      Widget chatRoom({required String roomId, required String theme}) {
+        return HookBuilder(builder: (context) {
+          // Plain function - fresh on every build, but...
+          void onConnected() {
+            logs.add('Connected with theme: $theme');
+          }
+
+          useEffect(() {
+            // Register callback with external system
+            // The external system holds this reference!
+            externalSystem.onConnected = onConnected;
+            return () => externalSystem.onConnected = null;
+          }, [roomId]); // Only depends on roomId, not theme
+
+          return Text('$roomId $theme', textDirection: TextDirection.ltr);
+        });
       }
 
-      expectedNumber = 42;
-      await tester.pumpWidget(buildWidget());
-      event();
-      expect(capturedNumber, 42);
+      await tester.pumpWidget(chatRoom(roomId: 'room1', theme: 'light'));
 
-      expectedNumber = 21;
-      await tester.pumpWidget(buildWidget());
-      event();
-      expect(capturedNumber, 21);
+      // Effect ran, registered callback with connection
+      externalSystem.fireConnected();
+      expect(logs, ['Connected with theme: light']);
+      logs.clear();
+
+      // User changes theme (but NOT roomId)
+      await tester.pumpWidget(chatRoom(roomId: 'room1', theme: 'dark'));
+
+      // A NEW onConnected function was created with theme='dark'
+      // BUT the effect didn't re-run, so connection still has OLD callback!
+      externalSystem.fireConnected();
+      expect(logs, ['Connected with theme: light']);
+      logs.clear();
     });
 
-    testWidgets('effect event should pass in provided arguments to callback',
-        (tester) async {
-      late void Function(String args) event;
-      String? capturedArgs;
-
-      Widget buildWidget() {
-        return HookBuilder(
-          builder: (context) {
-            event = useEffectEvent((args) {
-              capturedArgs = args;
-            });
-            return const SizedBox();
-          },
-        );
-      }
-
-      await tester.pumpWidget(buildWidget());
-      event('Hello');
-      expect(capturedArgs, 'Hello');
-
-      await tester.pumpWidget(buildWidget());
-      event('World!');
-      expect(capturedArgs, 'World!');
-    });
-
-    testWidgets('effect event should return value returned by callback',
-        (tester) async {
-      late String Function() event;
-      late String expectedReturnValue;
-
-      Widget buildWidget() {
-        return HookBuilder(
-          builder: (context) {
-            event = useEffectEvent(() {
-              return expectedReturnValue;
-            });
-            return const SizedBox();
-          },
-        );
-      }
-
-      expectedReturnValue = 'Hello';
-      await tester.pumpWidget(buildWidget());
-      expect(event(), 'Hello');
-
-      expectedReturnValue = 'World!';
-      await tester.pumpWidget(buildWidget());
-      expect(event(), 'World!');
-    });
-
-    /// Simulates the example use case: effect depends on `url` but reads
-    /// `itemCount` via useEffectEvent without adding it to dependencies.
     testWidgets(
-        'effect re-runs only when keys change, not when captured values change',
+        'useEffectEvent solves the external system stale reference problem',
         (tester) async {
-      final loggedVisits = <String>[];
-      var effectRunCount = 0;
+      final externalSystem = _MockConnection();
+      final logs = <String>[];
 
-      await tester.pumpWidget(
-        Page(
-          url: '/home',
-          itemCount: 5,
-          onVisit: loggedVisits.add,
-          onEffect: () => effectRunCount++,
-        ),
-      );
+      Widget chatRoom({required String roomId, required String theme}) {
+        return HookBuilder(builder: (context) {
+          // useEffectEvent - always sees latest theme via ref indirection
+          final onConnected = useEffectEvent(() {
+            logs.add('Connected with theme: $theme');
+          });
 
-      expect(effectRunCount, 1);
-      expect(loggedVisits, ['/home:5']);
+          useEffect(() {
+            // Register callback that delegates to useEffectEvent
+            externalSystem.onConnected = () => onConnected.call();
+            return () => externalSystem.onConnected = null;
+          }, [roomId]); // Only depends on roomId, theme accessed via ref
 
-      // Change itemCount only
-      await tester.pumpWidget(
-        Page(
-          url: '/home',
-          itemCount: 10,
-          onVisit: loggedVisits.add,
-          onEffect: () => effectRunCount++,
-        ),
-      );
-
-      // Should NOT have re-run effect, no new log
-      expect(effectRunCount, 1);
-      expect(loggedVisits, ['/home:5']);
-
-      // Change url
-      await tester.pumpWidget(
-        Page(
-          url: '/about',
-          itemCount: 10,
-          onVisit: loggedVisits.add,
-          onEffect: () => effectRunCount++,
-        ),
-      );
-
-      // Should have re-ran effect, new log with latest itemCount
-      expect(effectRunCount, 2);
-      expect(loggedVisits, ['/home:5', '/about:10']);
-    });
-
-    /// This test documents the current behavior: effect events do NOT have
-    /// stable referential identity across builds. This differs from React's
-    /// useEffectEvent which returns a stable reference. As a consequence,
-    /// effect events should never be included in useEffect's keys.
-    testWidgets('returns different identity on each build', (tester) async {
-      final identities = <Function>[];
-
-      Widget buildWidget() {
-        return HookBuilder(
-          builder: (context) {
-            final event = useEffectEvent(() {});
-            identities.add(event);
-            return const SizedBox();
-          },
-        );
+          return Text('$roomId $theme', textDirection: TextDirection.ltr);
+        });
       }
 
-      await tester.pumpWidget(buildWidget());
-      await tester.pumpWidget(buildWidget());
-      await tester.pumpWidget(buildWidget());
+      await tester.pumpWidget(chatRoom(roomId: 'room1', theme: 'light'));
 
-      expect(identities.length, 3);
-      expect(identities[0], isNot(same(identities[1])));
-      expect(identities[1], isNot(same(identities[2])));
-      expect(identities[2], isNot(same(identities[0])));
+      externalSystem.fireConnected();
+      expect(logs, ['Connected with theme: light']);
+      logs.clear();
+
+      // User changes theme (but NOT roomId)
+      await tester.pumpWidget(chatRoom(roomId: 'room1', theme: 'dark'));
+
+      // Effect didn't re-run, BUT useEffectEvent uses ref indirection
+      // so the callback registered with connection delegates to latest
+      externalSystem.fireConnected();
+      expect(logs, ['Connected with theme: dark']);
+      logs.clear();
     });
 
     testWidgets('debugFillProperties', (tester) async {
@@ -177,41 +108,468 @@ void main() {
             .toStringDeep(),
         equalsIgnoringHashCodes(
           'HookBuilder\n'
-          ' │ useEffectEvent\n'
+          ' │ useEffectEvent<() => Null>\n'
           ' └SizedBox(renderObject: RenderConstrainedBox#00000)\n',
         ),
       );
     });
   });
-}
 
-class Page extends HookWidget {
-  const Page({
-    super.key,
-    required this.url,
-    required this.itemCount,
-    required this.onVisit,
-    required this.onEffect,
-  });
+  // These tests are adapted from React's useEffectEvent tests:
+  // https://github.com/facebook/react/blob/main/packages/react-reconciler/src/__tests__/useEffectEvent-test.js
+  group("React's useEffectEvent", () {
+    testWidgets('memoizes basic case correctly', (tester) async {
+      Widget counter(int incrementBy) {
+        return HookBuilder(builder: (context) {
+          final count = useState(0);
 
-  final String url;
-  final int itemCount;
-  final void Function(String) onVisit;
-  final void Function() onEffect;
+          final onClick = useEffectEvent(() {
+            count.value += incrementBy;
+          });
 
-  @override
-  Widget build(BuildContext context) {
-    // ignore: avoid_types_on_closure_parameters
-    final logVisit = useEffectEvent((String visitedUrl) {
-      onVisit('$visitedUrl:$itemCount');
+          return GestureDetector(
+            onTap: onClick.call,
+            child: Text(
+              'Count: ${count.value}',
+              textDirection: TextDirection.ltr,
+            ),
+          );
+        });
+      }
+
+      await tester.pumpWidget(counter(1));
+      expect(find.text('Count: 0'), findsOneWidget);
+
+      await tester.tap(find.byType(GestureDetector));
+      await tester.pump();
+      expect(find.text('Count: 1'), findsOneWidget);
+
+      await tester.tap(find.byType(GestureDetector));
+      await tester.pump();
+      expect(find.text('Count: 2'), findsOneWidget);
+
+      // Increase the increment prop amount
+      await tester.pumpWidget(counter(10));
+      expect(find.text('Count: 2'), findsOneWidget);
+
+      // Event uses the new prop
+      await tester.tap(find.byType(GestureDetector));
+      await tester.pump();
+      expect(find.text('Count: 12'), findsOneWidget);
     });
 
-    useEffect(() {
-      onEffect();
-      logVisit(url);
-      return null;
-    }, [url]);
+    testWidgets('can be defined more than once', (tester) async {
+      Widget counter(int incrementBy) {
+        return HookBuilder(builder: (context) {
+          final count = useState(0);
 
-    return const SizedBox();
+          final onIncrement = useEffectEvent(() {
+            count.value += incrementBy;
+          });
+
+          final onMultiply = useEffectEvent(() {
+            count.value *= incrementBy;
+          });
+
+          return Column(
+            textDirection: TextDirection.ltr,
+            children: [
+              GestureDetector(
+                key: const Key('increment'),
+                onTap: onIncrement.call,
+                child: const Text(
+                  'Increment',
+                  textDirection: TextDirection.ltr,
+                ),
+              ),
+              GestureDetector(
+                key: const Key('multiply'),
+                onTap: onMultiply.call,
+                child: const Text(
+                  'Multiply',
+                  textDirection: TextDirection.ltr,
+                ),
+              ),
+              Text(
+                'Count: ${count.value}',
+                textDirection: TextDirection.ltr,
+              ),
+            ],
+          );
+        });
+      }
+
+      await tester.pumpWidget(counter(5));
+      expect(find.text('Count: 0'), findsOneWidget);
+
+      await tester.tap(find.byKey(const Key('increment')));
+      await tester.pump();
+      expect(find.text('Count: 5'), findsOneWidget);
+
+      await tester.tap(find.byKey(const Key('multiply')));
+      await tester.pump();
+      expect(find.text('Count: 25'), findsOneWidget);
+    });
+
+    // Note: Unlike React, flutter_hooks runs effects synchronously during
+    // initHook, not in a separate phase after commit. This makes it impossible
+    // to distinguish between "called during build" and "called from effect"
+    // using scheduler phase detection. This test is skipped as the behavior
+    // cannot be implemented without changes to flutter_hooks core.
+    testWidgets('throws when called during build', (tester) async {
+      await tester.pumpWidget(
+        HookBuilder(builder: (context) {
+          final onClick = useEffectEvent(() {});
+
+          // Calling useEffectEvent during build should throw
+          onClick.call();
+
+          return const SizedBox();
+        }),
+      );
+
+      final exception = tester.takeException();
+      expect(exception, isA<FlutterError>());
+      expect(
+        (exception! as FlutterError).message,
+        contains(
+          "A function wrapped in useEffectEvent can't be called during build.",
+        ),
+      );
+    }, skip: true);
+
+    testWidgets("useEffect shouldn't re-fire when event handlers change",
+        (tester) async {
+      final logs = <String>[];
+
+      Widget counter(int incrementBy) {
+        return HookBuilder(builder: (context) {
+          final count = useState(0);
+
+          final increment = useEffectEvent(([int? amount]) {
+            count.value += amount ?? incrementBy;
+          });
+
+          useEffect(() {
+            logs.add('Effect: by ${incrementBy * 2}');
+            increment.call(incrementBy * 2);
+            return null;
+          }, [incrementBy]);
+
+          return Column(
+            textDirection: TextDirection.ltr,
+            children: [
+              GestureDetector(
+                onTap: () => increment.call(),
+                child: const Text(
+                  'Increment',
+                  textDirection: TextDirection.ltr,
+                ),
+              ),
+              Text('Count: ${count.value}', textDirection: TextDirection.ltr),
+            ],
+          );
+        });
+      }
+
+      await tester.pumpWidget(counter(1));
+      expect(find.text('Increment'), findsOneWidget);
+      expect(find.text('Count: 2'), findsOneWidget);
+      expect(logs, ['Effect: by 2']);
+      logs.clear();
+
+      // Tap button - effect should NOT re-run
+      await tester.tap(find.byType(GestureDetector));
+      await tester.pump();
+      expect(find.text('Increment'), findsOneWidget);
+      expect(find.text('Count: 3'), findsOneWidget);
+      expect(logs, <String>[]); // No effect re-run
+      logs.clear();
+
+      // Tap button again
+      await tester.tap(find.byType(GestureDetector));
+      await tester.pump();
+      expect(find.text('Increment'), findsOneWidget);
+      expect(find.text('Count: 4'), findsOneWidget);
+      expect(logs, <String>[]); // Still no effect re-run
+      logs.clear();
+
+      // Change incrementBy prop - effect SHOULD re-run
+      await tester.pumpWidget(counter(10));
+      expect(find.text('Increment'), findsOneWidget);
+      expect(find.text('Count: 24'), findsOneWidget);
+      expect(logs, ['Effect: by 20']);
+      logs.clear();
+
+      // Tap button - uses new incrementBy value
+      await tester.tap(find.byType(GestureDetector));
+      await tester.pump();
+      expect(find.text('Increment'), findsOneWidget);
+      expect(find.text('Count: 34'), findsOneWidget);
+      expect(logs, <String>[]); // No effect re-run
+      logs.clear();
+    });
+
+    testWidgets('is stable in a custom hook', (tester) async {
+      final logs = <String>[];
+
+      Widget counter(int incrementBy) {
+        return HookBuilder(builder: (context) {
+          final count = useState(0);
+
+          final increment = useEffectEvent(([int? amount]) {
+            count.value += amount ?? incrementBy;
+          });
+
+          useEffect(() {
+            logs.add('Effect: by ${incrementBy * 2}');
+            increment.call(incrementBy * 2);
+            return null;
+          }, [incrementBy]);
+
+          return Column(
+            textDirection: TextDirection.ltr,
+            children: [
+              GestureDetector(
+                onTap: () => increment.call(),
+                child: const Text(
+                  'Increment',
+                  textDirection: TextDirection.ltr,
+                ),
+              ),
+              Text(
+                'Count: ${count.value}',
+                textDirection: TextDirection.ltr,
+              ),
+            ],
+          );
+        });
+      }
+
+      await tester.pumpWidget(counter(1));
+      expect(find.text('Increment'), findsOneWidget);
+      expect(find.text('Count: 2'), findsOneWidget);
+      expect(logs, ['Effect: by 2']);
+      logs.clear();
+
+      // Tap button - effect should NOT re-run
+      await tester.tap(find.byType(GestureDetector));
+      await tester.pump();
+      expect(find.text('Increment'), findsOneWidget);
+      expect(find.text('Count: 3'), findsOneWidget);
+      expect(logs, <String>[]); // No effect re-run
+      logs.clear();
+
+      // Tap button again
+      await tester.tap(find.byType(GestureDetector));
+      await tester.pump();
+      expect(find.text('Increment'), findsOneWidget);
+      expect(find.text('Count: 4'), findsOneWidget);
+      expect(logs, <String>[]); // Still no effect re-run
+      logs.clear();
+
+      // Change incrementBy prop - effect SHOULD re-run
+      await tester.pumpWidget(counter(10));
+      expect(find.text('Increment'), findsOneWidget);
+      expect(find.text('Count: 24'), findsOneWidget);
+      expect(logs, ['Effect: by 20']);
+      logs.clear();
+
+      // Tap button - uses new incrementBy value
+      await tester.tap(find.byType(GestureDetector));
+      await tester.pump();
+      expect(find.text('Increment'), findsOneWidget);
+      expect(find.text('Count: 34'), findsOneWidget);
+      expect(logs, <String>[]); // No effect re-run
+      logs.clear();
+    });
+
+    testWidgets("doesn't provide a stable identity", (tester) async {
+      final logs = <String>[];
+
+      Widget counter(bool shouldRender, int value) {
+        return HookBuilder(builder: (context) {
+          final onClick = useEffectEvent(() {
+            logs.add('onClick, shouldRender=$shouldRender, value=$value');
+          });
+
+          // onClick doesn't have a stable function identity so this effect
+          // will fire on every render. In a real app useEffectEvent functions
+          // should NOT be passed as a dependency, this is for testing only.
+          useEffect(() {
+            onClick.call();
+            return null;
+          }, [onClick]);
+
+          useEffect(() {
+            onClick.call();
+            return null;
+          }, [shouldRender]);
+
+          return const SizedBox();
+        });
+      }
+
+      // Initial render - both effects run
+      await tester.pumpWidget(counter(true, 0));
+      expect(logs, [
+        'onClick, shouldRender=true, value=0',
+        'onClick, shouldRender=true, value=0',
+      ]);
+      logs.clear();
+
+      // Update value only - only the onClick-dependent effect runs
+      // (because onClick identity changed)
+      await tester.pumpWidget(counter(true, 1));
+      expect(logs, ['onClick, shouldRender=true, value=1']);
+      logs.clear();
+
+      // Update shouldRender - both effects run
+      // (onClick identity changed AND shouldRender changed)
+      await tester.pumpWidget(counter(false, 2));
+      expect(logs, [
+        'onClick, shouldRender=false, value=2',
+        'onClick, shouldRender=false, value=2',
+      ]);
+      logs.clear();
+    });
+
+    testWidgets('event handlers always see the latest committed value',
+        (tester) async {
+      final logs = <String>[];
+      EffectEvent<String Function()>? committedEventHandler;
+
+      Widget app(int value) {
+        return HookBuilder(builder: (context) {
+          final event = useEffectEvent(() {
+            return 'Value seen by useEffectEvent: $value';
+          });
+
+          // Effect with empty deps - runs once, stores handler
+          useEffect(() {
+            logs.add('Commit new event handler');
+            committedEventHandler = event;
+            return null;
+          }, const []);
+
+          return Text(
+            'Latest rendered value $value',
+            textDirection: TextDirection.ltr,
+          );
+        });
+      }
+
+      // Initial render
+      await tester.pumpWidget(app(1));
+      expect(find.text('Latest rendered value 1'), findsOneWidget);
+      expect(logs, ['Commit new event handler']);
+      expect(committedEventHandler!.call(), 'Value seen by useEffectEvent: 1');
+      logs.clear();
+
+      // Update - effect should NOT re-run (empty deps)
+      await tester.pumpWidget(app(2));
+      expect(find.text('Latest rendered value 2'), findsOneWidget);
+      // No new event handler should be committed, because deps is empty
+      expect(logs, <String>[]);
+      // But the event handler should still be able to see the latest value
+      expect(committedEventHandler!.call(), 'Value seen by useEffectEvent: 2');
+      logs.clear();
+    });
+
+    testWidgets('integration: implements docs chat room example',
+        (tester) async {
+      final logs = <String>[];
+
+      _Connection createConnection(String roomId) {
+        return _Connection(
+          roomId: roomId,
+          onLog: logs.add,
+        );
+      }
+
+      Widget chatRoom({required String roomId, required String theme}) {
+        return HookBuilder(builder: (context) {
+          final onConnected = useEffectEvent(() {
+            logs.add('Connected! theme: $theme');
+          });
+
+          useEffect(() {
+            final connection = createConnection(roomId);
+            connection.on('connected', () => onConnected.call());
+            connection.connect();
+            return connection.disconnect;
+          }, [roomId]);
+
+          return Text(
+            'Welcome to the $roomId room!',
+            textDirection: TextDirection.ltr,
+          );
+        });
+      }
+
+      // Initial render
+      await tester.pumpWidget(chatRoom(roomId: 'general', theme: 'light'));
+      expect(find.text('Welcome to the general room!'), findsOneWidget);
+      expect(logs, ['Connected! theme: light']);
+      logs.clear();
+
+      // Change roomId only - should trigger reconnect
+      // Note: flutter_hooks runs new effect before old cleanup (unlike React)
+      await tester.pumpWidget(chatRoom(roomId: 'music', theme: 'light'));
+      expect(find.text('Welcome to the music room!'), findsOneWidget);
+      expect(logs, ['Connected! theme: light', 'Disconnected from general']);
+      logs.clear();
+
+      // Change theme only - should NOT trigger reconnect
+      await tester.pumpWidget(chatRoom(roomId: 'music', theme: 'dark'));
+      expect(find.text('Welcome to the music room!'), findsOneWidget);
+      expect(logs, <String>[]); // No reconnect!
+      logs.clear();
+
+      // Change roomId only - should trigger reconnect with latest theme
+      await tester.pumpWidget(chatRoom(roomId: 'travel', theme: 'dark'));
+      expect(find.text('Welcome to the travel room!'), findsOneWidget);
+      expect(logs, ['Connected! theme: dark', 'Disconnected from music']);
+      logs.clear();
+    });
+  });
+}
+
+/// Mock external system that holds callback references (e.g., WebSocket, Timer)
+class _MockConnection {
+  void Function()? onConnected;
+
+  void fireConnected() {
+    onConnected?.call();
+  }
+}
+
+/// Simulates a connection like React's createConnection in the docs example.
+/// Calls the 'connected' callback immediately on connect() for testing purposes.
+class _Connection {
+  _Connection({required this.roomId, required this.onLog});
+
+  final String roomId;
+  final void Function(String) onLog;
+  void Function()? _connectedCallback;
+
+  void on(String event, void Function() callback) {
+    if (_connectedCallback != null) {
+      throw StateError('Cannot add the handler twice.');
+    }
+    if (event != 'connected') {
+      throw ArgumentError('Only "connected" event is supported.');
+    }
+    _connectedCallback = callback;
+  }
+
+  void connect() {
+    // In React's test, this uses setTimeout. We call immediately for simplicity.
+    _connectedCallback?.call();
+  }
+
+  void disconnect() {
+    onLog('Disconnected from $roomId');
+    _connectedCallback = null;
   }
 }

--- a/packages/flutter_hooks/test/use_effect_event_test.dart
+++ b/packages/flutter_hooks/test/use_effect_event_test.dart
@@ -1,0 +1,137 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
+
+import 'mock.dart';
+
+void main() {
+  group('useEffectEvent', () {
+    testWidgets('effect event should always invoke callback with latest state',
+        (tester) async {
+      late void Function() event;
+      late int expectedNumber;
+      int? capturedNumber;
+
+      Widget buildWidget() {
+        return HookBuilder(
+          builder: (context) {
+            final current = expectedNumber;
+            event = useEffectEvent(() {
+              capturedNumber = current;
+            });
+            return const SizedBox();
+          },
+        );
+      }
+
+      expectedNumber = 42;
+      await tester.pumpWidget(buildWidget());
+      event();
+      expect(capturedNumber, 42);
+
+      expectedNumber = 21;
+      await tester.pumpWidget(buildWidget());
+      event();
+      expect(capturedNumber, 21);
+    });
+
+    testWidgets('effect event should pass in provided arguments to callback',
+        (tester) async {
+      late void Function(String args) event;
+      String? capturedArgs;
+
+      Widget buildWidget() {
+        return HookBuilder(
+          builder: (context) {
+            event = useEffectEvent((args) {
+              capturedArgs = args;
+            });
+            return const SizedBox();
+          },
+        );
+      }
+
+      await tester.pumpWidget(buildWidget());
+      event('Hello');
+      expect(capturedArgs, 'Hello');
+
+      await tester.pumpWidget(buildWidget());
+      event('World!');
+      expect(capturedArgs, 'World!');
+    });
+
+    testWidgets('effect event should return value returned by callback',
+        (tester) async {
+      late String Function() event;
+      late String expectedReturnValue;
+
+      Widget buildWidget() {
+        return HookBuilder(
+          builder: (context) {
+            event = useEffectEvent(() {
+              return expectedReturnValue;
+            });
+            return const SizedBox();
+          },
+        );
+      }
+
+      expectedReturnValue = 'Hello';
+      await tester.pumpWidget(buildWidget());
+      expect(event(), 'Hello');
+
+      expectedReturnValue = 'World!';
+      await tester.pumpWidget(buildWidget());
+      expect(event(), 'World!');
+    });
+
+    // This test documents the current behavior: effect events do NOT have
+    // stable referential identity across builds. This differs from React's
+    // useEffectEvent which returns a stable reference. As a consequence, effect
+    // events should never be included in useEffect's keys.
+    testWidgets('returns different identity on each build', (tester) async {
+      final identities = <Function>[];
+
+      Widget buildWidget() {
+        return HookBuilder(
+          builder: (context) {
+            final event = useEffectEvent(() {});
+            identities.add(event);
+            return const SizedBox();
+          },
+        );
+      }
+
+      await tester.pumpWidget(buildWidget());
+      await tester.pumpWidget(buildWidget());
+      await tester.pumpWidget(buildWidget());
+
+      expect(identities.length, 3);
+      expect(identities[0], isNot(same(identities[1])));
+      expect(identities[1], isNot(same(identities[2])));
+      expect(identities[2], isNot(same(identities[0])));
+    });
+
+    testWidgets('debugFillProperties', (tester) async {
+      await tester.pumpWidget(
+        HookBuilder(builder: (context) {
+          useEffectEvent(() {});
+          return const SizedBox();
+        }),
+      );
+
+      final element = tester.element(find.byType(HookBuilder));
+
+      expect(
+        element
+            .toDiagnosticsNode(style: DiagnosticsTreeStyle.offstage)
+            .toStringDeep(),
+        equalsIgnoringHashCodes(
+          'HookBuilder\n'
+          ' │ useEffectEvent\n'
+          ' └SizedBox(renderObject: RenderConstrainedBox#00000)\n',
+        ),
+      );
+    });
+  });
+}


### PR DESCRIPTION
**See #488**

Adds `useEffectEvent`, a new primitive hook inspired by [React's useEffectEvent](https://react.dev/reference/react/useEffectEvent). This hook extracts non-reactive logic out of `useEffect`, allowing callbacks to access the latest values and states without adding them to the effect's dependencies.

### Summary

- Add `EffectEvent<T>` wrapper class that provides type-safe access to the latest callback via ref indirection
- Add `useEffectEvent<T>` hook that returns an `EffectEvent<T>` wrapper
- The callback is accessed via `event.call()` which reads from the internal ref at call time

### Use Case

When an effect registers a callback with an external system (WebSocket, Timer, etc.), that system holds onto the callback reference. If the effect doesn't re-run when props change, the external system has a stale callback.

```dart
class ChatRoom extends HookWidget {
  final String roomId;
  final ThemeData theme;

  @override
  Widget build(BuildContext context) {
    final onConnected = useEffectEvent(() {
      showNotification('Connected!', theme);  // Always sees latest theme
    });

    useEffect(() {
      final connection = createConnection(roomId);
      connection.onConnected = () => onConnected.call();
      connection.connect();
      return connection.disconnect;
    }, [roomId]);  // No theme dependency needed
  }
}
```

### API

```dart
class EffectEvent<T extends Function> {
  /// Always returns the latest callback stored in the shared ref.
  T get call;
}

EffectEvent<T> useEffectEvent<T extends Function>(T callback);
```

### Implementation

The hook uses **ref indirection**: the `EffectEvent` wrapper holds a reference to a mutable `ObjectRef`, not the callback itself. When the widget rebuilds, `didUpdateHook` updates the ref with the latest callback. Calling `event.call()` reads from the ref at invocation time, so it always returns the current callback.

### Why the `EffectEvent` Wrapper?

The hook returns an `EffectEvent<T>` wrapper instead of `T` directly because Dart generics cannot preserve the exact function signature when returning. Alternatives considered:

- **Return `Function`** - Loses type-safety
- **Multiple variants** (`useEffectEvent0`, `useEffectEvent1<A>`, etc.) - Verbose, doesn't scale

The wrapper provides type-safety (`event.call` returns `T`) and a unified interface.

### Caveats

1. **Only call inside Effects or event handlers** - Do not call during build
2. **Don't pass to child widgets** - Effect events are for local use
3. **Unstable identity** - Returns a new `EffectEvent` instance each build; never include in `useEffect`'s keys
