### PR TITLE
Run dispose before effect when keys change (#335)

### DIFF
--- a/packages/flutter_hooks/lib/src/framework.dart
+++ b/packages/flutter_hooks/lib/src/framework.dart
@@ -477,8 +477,7 @@ Type mismatch between hooks:
           .._hook = hook
           ..didUpdateHook(previousHook);
       } else {
-        _needDispose ??= LinkedList();
-        _needDispose!.add(_Entry(_currentHookState!.value));
+        _currentHookState!.value.dispose();
         _currentHookState!.value = _createHookState<R>(hook);
       }
     }

--- a/packages/flutter_hooks/lib/src/framework.dart
+++ b/packages/flutter_hooks/lib/src/framework.dart
@@ -477,7 +477,20 @@ Type mismatch between hooks:
           .._hook = hook
           ..didUpdateHook(previousHook);
       } else {
-        _currentHookState!.value.dispose();
+        try {
+          _currentHookState!.value.dispose();
+        } catch (exception, stack) {
+          FlutterError.reportError(
+            FlutterErrorDetails(
+              exception: exception,
+              stack: stack,
+              library: 'hooks library',
+              context: DiagnosticsNode.message(
+                'while disposing ${_currentHookState!.value.runtimeType}',
+              ),
+            ),
+          );
+        }
         _currentHookState!.value = _createHookState<R>(hook);
       }
     }

--- a/packages/flutter_hooks/test/hook_widget_test.dart
+++ b/packages/flutter_hooks/test/hook_widget_test.dart
@@ -79,8 +79,8 @@ void main() {
     );
 
     verifyInOrder([
-      second(),
       first(),
+      second(),
     ]);
     verifyNoMoreInteractions(first);
     verifyNoMoreInteractions(second);
@@ -94,6 +94,7 @@ void main() {
     verifyNoMoreInteractions(first);
     verifyNoMoreInteractions(second);
   });
+
   testWidgets('hooks are disposed in reverse order on unmount', (tester) async {
     final first = MockDispose();
     final second = MockDispose();
@@ -470,6 +471,7 @@ void main() {
     verify(dispose2()).called(1);
     verifyNoMoreInteractions(dispose);
   });
+
   testWidgets('keys recreate hookstate', (tester) async {
     List<Object?>? keys;
 
@@ -518,10 +520,10 @@ void main() {
     await tester.pumpWidget($build());
 
     verifyInOrder([
+      dispose(),
       createState(),
       initHook(),
       build(context),
-      dispose(),
     ]);
     verifyNoMoreHookInteraction();
 
@@ -553,10 +555,10 @@ void main() {
     await tester.pumpWidget($build());
 
     verifyInOrder([
+      dispose(),
       createState(),
       initHook(),
       build(context),
-      dispose(),
     ]);
     verifyNoMoreHookInteraction();
   });

--- a/packages/flutter_hooks/test/use_effect_test.dart
+++ b/packages/flutter_hooks/test/use_effect_test.dart
@@ -376,6 +376,33 @@ void main() {
     expect(tester.takeException(), isA<Exception>());
   });
 
+  testWidgets('errors in dispose are handled on unmount', (tester) async {
+    final callOrder = <String>[];
+
+    await tester.pumpWidget(HookBuilder(builder: (context) {
+      useEffect(() {
+        callOrder.add('effect');
+        return () {
+          callOrder.add('dispose');
+          throw Exception();
+        };
+      }, const []);
+
+      return Container();
+    }));
+
+    expect(callOrder, ['effect']);
+    expect(tester.takeException(), isNull);
+    callOrder.clear();
+
+    // Unmount
+    await tester.pumpWidget(Container());
+
+    expect(callOrder, ['dispose']);
+    expect(tester.takeException(), isA<Exception>());
+    callOrder.clear();
+  });
+
   group('useEffect execution order', () {
     testWidgets('dispose runs before effect when keys change', (tester) async {
       // Regression test for https://github.com/rrousselGit/flutter_hooks/issues/335


### PR DESCRIPTION
## Summary

See #335

This PR changes the execution order of `useEffect` dispose and effect callbacks when keys change. Previously, the new effect ran before the old effect's dispose callback. Now, dispose runs first, matching React's `useEffect` behavior.

## Problem

When `useEffect` keys changed, the execution order was:

1. New effect runs
2. Old effect's dispose runs

This could cause issues when the dispose callback needs to clean up resources before the new effect initializes them.

## Solution

Changed the execution order so that when keys change:

1. Old effect's dispose runs first
2. New effect initializes second

## Tests

Added regression tests to verify the execution order:

- `dispose runs before effect when keys change`
- `dispose runs before effect on every build when keys are not provided`
- `dispose and effect run in group for each hook in declaration order`

Added tests to ensure errors in dispose are handled properly:
- `errors in dispose are handled when keys change`
- `errors in dispose are handled on unmount`

Updated existing tests to match the corrected behavior:

- `useEffect disposer called whenever callback called` (use_effect_test.dart)
- `hooks are disposed in reverse order when their keys changes` (hook_widget_test.dart)
- `keys recreate hookstate` (hook_widget_test.dart)

## Note on React Compatibility

This PR still does not fully match React's `useEffect` execution order due to fundamental architectural differences between Flutter and React:

1. **Multiple hooks in the same widget**: React batches all disposes before all effects (`dispose1 → dispose2 → effect1 → effect2`). This PR maintains synchronous per-hook execution (`dispose1 → effect1 → dispose2 → effect2`) to preserve backward compatibility with existing code that relies on effects running immediately during build.

2. **Parent-child ordering**: React runs child effects before parent effects (bottom-up) and parent cleanups before child cleanups on unmount (top-down). Achieving this in Flutter would require deferring effects to a post-frame callback, which would be a breaking change to the synchronous execution model.

Whether flutter_hooks should fully match these React behaviors is debatable. Doing so would introduce significant breaking changes, and it's unclear whether React's execution model is inherently better than Flutter hooks' model.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Hooks now dispose immediately when replaced by a different hook type, and disposal runs before the next effect when dependencies change, improving lifecycle ordering and cleanup reliability.

* **Tests**
  * Added and updated tests covering disposal ordering, keyed/unkeyed effect sequencing, per-hook ordering, and error propagation from disposers (including unmount).

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->